### PR TITLE
Rename Command to FluentCommand and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ MVVMFluent is a lightweight, source-only .NET library designed to simplify the M
 
 ## Features
 - Fluent Property Setters: Easily chain property setters with `Changed`, `Changing`, command reevaluation, and property change notifications.
-- Fluent Command Setup: Define commands with `Do` methods and conditional execution via `If`.
-- Generic `Command<T>`: Define commands with parameterized actions using a strongly-typed approach.
-- Implements `ICommand`: Both `Command` and `Command<T>` implement the `ICommand` interface, enabling full compatibility with WPF and other MVVM frameworks.
+- Fluent FluentCommand Setup: Define commands with `Do` methods and conditional execution via `If`.
+- Generic `FluentCommand<T>`: Define commands with parameterized actions using a strongly-typed approach.
+- Implements `ICommand`: Both `FluentCommand` and `FluentCommand<T>` implement the `ICommand` interface, enabling full compatibility with WPF and other MVVM frameworks.
 - Source-Only Package: Integrates directly into your project as source code, minimizing dependencies.
 - Global Namespace Integration: Fully qualified `global::` namespaces for all system types and dependencies.
 - Disposal Management: Manage and clean up resources with built-in `Dispose` functionality.
@@ -51,13 +51,13 @@ public class MyViewModel : ViewModelBase
 ```
 Here, the `Set` method is used directly to assign the new value to the property without needing any additional configuration like `Changing` or `Changed`.
 
-### Fluent `Command` Setup
+### Fluent `FluentCommand` Setup
 Commands in MVVMFluent can be easily defined with `Do` methods, and you can add conditional execution using `If`.
 
 ```csharp
 public class MyViewModel : ViewModelBase
 {
-    public Command SaveCommand => Do(Save)
+    public FluentCommand SaveCommand => Do(Save)
                                   .If(CanSave);
 
     private void Save()
@@ -69,13 +69,13 @@ public class MyViewModel : ViewModelBase
 }
 ```
 
-### Using `Command<T>` for Generic Commands
-In cases where you need commands that accept a parameter, you can use the generic `Command<T>`. Both `Command` and `Command<T>` implement the `ICommand` interface, making them compatible with WPF or any other MVVM framework that supports `ICommand`.
+### Using `FluentCommand<T>` for Generic Commands
+In cases where you need commands that accept a parameter, you can use the generic `FluentCommand<T>`. Both `FluentCommand` and `FluentCommand<T>` implement the `ICommand` interface, making them compatible with WPF or any other MVVM framework that supports `ICommand`.
 
 ```csharp
 public class MyViewModel : ViewModelBase
 {
-    public Command<string> SaveWithMessageCommand => Do<string>(message => Save(message))
+    public FluentCommand<string> SaveWithMessageCommand => Do<string>(message => Save(message))
                                                      .If(message => !string.IsNullOrEmpty(message));
 
     private void Save(string message)
@@ -85,7 +85,7 @@ public class MyViewModel : ViewModelBase
     }
 }
 ```
-This example demonstrates how `Command<T>` can be used to handle parameterized commands with strongly-typed arguments.
+This example demonstrates how `FluentCommand<T>` can be used to handle parameterized commands with strongly-typed arguments.
 
 ### Using `Notify(nameof(...))` for Property Change Notifications
 You can also notify multiple properties when setting a value. This is useful when other properties are derived from or depend on the value being set.
@@ -129,7 +129,7 @@ public class MyViewModel : ViewModelBase
 ```
 In this example, if the `Counter` property hasn’t been set before, the Get(10) will return 10 as the default value.
 
-### Asynchronous Command (`AsyncCommand`)
+### Asynchronous FluentCommand (`AsyncCommand`)
 The AsyncCommand in the MVVMFluent library is designed to simplify asynchronous command execution with built-in support for cancellation, progress reporting, and exception handling. It allows you to execute long-running tasks without blocking the UI thread, while maintaining full control over the command's lifecycle.
 
 **Key Features:**
@@ -168,14 +168,14 @@ public bool CanLoad { get => Get(true); set => Set(value); }
 
 In XAML:
 ```xml
-<Button Content="Load" Command="{Binding LoadCommand}" />
+<Button Content="Load" FluentCommand="{Binding LoadCommand}" />
 <ProgressBar Visibility="{Binding LoadCommand.IsRunning, Converter={StaticResource BoolToVisibilityConverter}}" />
-<Button Content="Cancel" Command="{Binding LoadCommand.CancelCommand}" />
+<Button Content="Cancel" FluentCommand="{Binding LoadCommand.CancelCommand}" />
 ```
 
 This example demonstrates how AsyncCommand integrates with both your view model and XAML, providing a responsive and user-friendly interface for long-running or cancellable operations.
 
-### Asynchronous Command with Parameter (`AsyncCommand<T>`)
+### Asynchronous FluentCommand with Parameter (`AsyncCommand<T>`)
 The `AsyncCommand<T>` extends the functionality of AsyncCommand by allowing you to pass a parameter of type `T` to the asynchronous execution logic. This makes it ideal for scenarios where the command needs to act on dynamic data or context-specific parameters. Like `AsyncCommand`, it supports cancellation, progress reporting, and exception handling, while maintaining the same fluent API for configuration.
 
 ### Validation Fluent Setter (`ValidationFluentSetter<TValue>`)
@@ -211,7 +211,7 @@ private bool IsCommentValid(string? value)
 **Conditional Validation** allows for validation checks to occur only when certain conditions are met, using the `When(value)` method. Additionally, the command can be set to execute only if the validation passes by using the `IfValid()` method, ensuring that the command is invoked only with valid input. For example:
 
 ```csharp
-// Remember to use .Notify(Command) on the setter
+// Remember to use .Notify(FluentCommand) on the setter
 public string? Comments
 {
     get => Get<string?>();
@@ -227,7 +227,7 @@ private bool IsCommentValid(string? value)
 }
 
 // Example command that executes only if the Comments property is valid
-public Command OkCommand => Do(() => ShowDialog(Comments)).IfValid(nameof(Comments));
+public FluentCommand OkCommand => Do(() => ShowDialog(Comments)).IfValid(nameof(Comments));
 ```
 Together, these methods enhance the user experience by providing responsive, context-sensitive validation feedback while ensuring adherence to application requirements.
 
@@ -298,7 +298,7 @@ public class MyDialogViewModel : IClosableViewModel, IResultViewModel<string>
 
     public Action? RequestCloseView { get; set; }
     public bool CanCloseView() => !string.IsNullOrEmpty(Result);
-    public Command CloseCommand => Do(Close);
+    public FluentCommand CloseCommand => Do(Close);
 
     public void Close()
     {
@@ -361,12 +361,12 @@ namespace MVVMFluent.Demo
                 .If(() => Comments?.Contains("Load") == true)
                 .Handle(HandleError);
 
-        public Command SaveCommand =>
+        public FluentCommand SaveCommand =>
                 Do(Save)
                 .IfValid(nameof(Name))
                 .If(() => !string.IsNullOrEmpty(Name));
 
-        public Command CloseCommand => Do(() => RequestCloseView?.Invoke()).If(CanCloseView);
+        public FluentCommand CloseCommand => Do(() => RequestCloseView?.Invoke()).If(CanCloseView);
         public Action? RequestCloseView { get; set; }
         public bool CanCloseView()
         {
@@ -413,7 +413,7 @@ namespace MVVMFluent.Demo
 In this complete example:
 - The `Name` property triggers the `SaveCommand` and notifies the `FullName` property on change.
 - The `Counter` property has a default value of `10`.
-- The `SaveWithMessageCommand` is a generic command (`Command<string>`) that accepts a string parameter.
+- The `SaveWithMessageCommand` is a generic command (`FluentCommand<string>`) that accepts a string parameter.
 - The `Close()` method is provided to dispose of resources when the view model is no longer needed.
 
 ## License

--- a/src/MVVMFluent.Demo/MainViewModel.cs
+++ b/src/MVVMFluent.Demo/MainViewModel.cs
@@ -18,7 +18,7 @@ internal class MainViewModel : ValidationViewModelBase
         set => When(value).Required().Notify(AsyncCommand, OkCommand).Set();
     }
 
-    public Command OkCommand => Do(() => ShowDialog(Input)).IfValid(nameof(Input));
+    public FluentCommand OkCommand => Do(() => ShowDialog(Input)).IfValid(nameof(Input));
 
     private bool CanExecute()
     {
@@ -54,7 +54,7 @@ internal class MainViewModel : ValidationViewModelBase
         ShowDialog(Input);
     }
 
-    public Command<string> HelpCommand => Do<string>(ShowDialog);
+    public FluentCommand<string> HelpCommand => Do<string>(ShowDialog);
 
     private void ShowDialog(string? input)
     {

--- a/src/MVVMFluent.Tests/ViewModelBaseCommandTests.cs
+++ b/src/MVVMFluent.Tests/ViewModelBaseCommandTests.cs
@@ -6,14 +6,14 @@ public class ViewModelBaseCommandTests
 {
     class CommandTestViewModel(Action execute) : ViewModelBase
     {
-        public ICommand Command => Do(execute);
+        public ICommand FluentCommand => Do(execute);
     }
 
     [Fact]
     internal void Do_CreatesCommand()
     {
         var viewModel = new CommandTestViewModel(() => { });
-        var command = viewModel.Command;
+        var command = viewModel.FluentCommand;
         Assert.NotNull(command);
     }
 
@@ -23,13 +23,13 @@ public class ViewModelBaseCommandTests
         var didExecute = false;
         void execute() => didExecute = true;
         var viewModel = new CommandTestViewModel(execute);
-        viewModel.Command.Execute(null);
+        viewModel.FluentCommand.Execute(null);
         Assert.True(didExecute);
     }
 
     class CommandParameterTestViewModel(Action<object?> execute) : ViewModelBase
     {
-        public ICommand Command => Do(execute);
+        public ICommand FluentCommand => Do(execute);
     }
 
     [Fact]
@@ -41,13 +41,13 @@ public class ViewModelBaseCommandTests
             parameter = obj;
         }
         var viewModel = new CommandParameterTestViewModel(execute);
-        viewModel.Command.Execute("Test");
+        viewModel.FluentCommand.Execute("Test");
         Assert.Equal("Test", parameter);
     }
 
     class CommandIfTestViewModel(Action execute, Func<bool> canExecute) : ViewModelBase
     {
-        public ICommand Command => Do(execute).If(canExecute);
+        public ICommand FluentCommand => Do(execute).If(canExecute);
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class ViewModelBaseCommandTests
         void execute() => didExecute = true;
         var viewModel = new CommandIfTestViewModel(execute, () => true);
 
-        viewModel.Command.Execute(null);
+        viewModel.FluentCommand.Execute(null);
 
         Assert.True(didExecute);
     }
@@ -69,7 +69,7 @@ public class ViewModelBaseCommandTests
         void execute() { }
         var viewModel = new CommandIfTestViewModel(execute, canExecute);
 
-        var result = viewModel.Command.CanExecute(null);
+        var result = viewModel.FluentCommand.CanExecute(null);
 
         Assert.False(result);
     }
@@ -82,14 +82,14 @@ public class ViewModelBaseCommandTests
         void execute() => didExecute = true;
         var viewModel = new CommandIfTestViewModel(execute, canExecute);
 
-        viewModel.Command.Execute(null);
+        viewModel.FluentCommand.Execute(null);
 
         Assert.False(didExecute);
     }
 
     class CommandIfParameterTestViewModel(Action<object?> execute, Func<object, bool> canExecute) : ViewModelBase
     {
-        public ICommand Command => Do(execute).If(canExecute);
+        public ICommand FluentCommand => Do(execute).If(canExecute);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class ViewModelBaseCommandTests
         object? parameter = null;
         void execute(object? obj) => parameter = obj;
         var viewModel = new CommandIfParameterTestViewModel(execute, _ => true);
-        viewModel.Command.Execute("Test");
+        viewModel.FluentCommand.Execute("Test");
         Assert.Equal("Test", parameter);
     }
 
@@ -108,7 +108,7 @@ public class ViewModelBaseCommandTests
         bool canExecute(object obj) => false;
         void execute(object? obj) { }
         var viewModel = new CommandIfParameterTestViewModel(execute, canExecute);
-        var result = viewModel.Command.CanExecute(null);
+        var result = viewModel.FluentCommand.CanExecute(null);
         Assert.False(result);
     }
 
@@ -119,7 +119,7 @@ public class ViewModelBaseCommandTests
         var didExecute = false;
         void execute(object? obj) => didExecute = true;
         var viewModel = new CommandIfParameterTestViewModel(execute, canExecute);
-        viewModel.Command.Execute("Test");
+        viewModel.FluentCommand.Execute("Test");
         Assert.False(didExecute);
     }
 
@@ -128,9 +128,9 @@ public class ViewModelBaseCommandTests
         public int Property
         {
             get => Get<int>();
-            set => When(value).Notify(Command).Set();
+            set => When(value).Notify(FluentCommand).Set();
         }
-        public IFluentCommand Command => Do(() => { }).If(canExecute);
+        public IFluentCommand FluentCommand => Do(() => { }).If(canExecute);
     }
 
     [Fact]
@@ -144,9 +144,9 @@ public class ViewModelBaseCommandTests
 
         var viewModel = new CommandPropertyNotifyTestViewModel(canExecute);
 
-        viewModel.Command.CanExecuteChanged += (sender, args) =>
+        viewModel.FluentCommand.CanExecuteChanged += (sender, args) =>
         {
-            viewModel.Command.CanExecute(null);
+            viewModel.FluentCommand.CanExecute(null);
         };
 
         viewModel.Property = 1;
@@ -158,7 +158,7 @@ public class ViewModelBaseCommandTests
     {
         private readonly Action _execute = execute;
 
-        public ICommand Command => Do(_execute);
+        public ICommand FluentCommand => Do(_execute);
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class ViewModelBaseCommandTests
         var didExecute = false;
         void execute() => didExecute = true;
         var viewModel = new CommandIfCanUseLocalVariableTestViewModel(execute);
-        viewModel.Command.Execute(null);
+        viewModel.FluentCommand.Execute(null);
         Assert.True(didExecute);
     }
 }

--- a/src/MVVMFluent.Tests/ViewModelBaseGenericsCommandTests.cs
+++ b/src/MVVMFluent.Tests/ViewModelBaseGenericsCommandTests.cs
@@ -1,13 +1,19 @@
 ﻿namespace MVVMFluent.Tests
 {
+    public class CommandViewModel : ViewModelBase
+    {
+    }
+
     public class ViewModelBaseGenericsCommandTests
     {
+        private readonly CommandViewModel _viewModel = new();
+
         [Fact]
         public void Execute_WhenCanExecuteIsTrue_CallsExecuteAction()
         {
             // Arrange
             var executeCalled = false;
-            var command = Command<string>.Do(param => executeCalled = true)
+            var command = FluentCommand<string>.Do(param => executeCalled = true, _viewModel)
                 .If(param => true); // CanExecute always returns true
 
             // Act
@@ -22,7 +28,7 @@
         {
             // Arrange
             var executeCalled = false;
-            var command = Command<string>.Do(param => executeCalled = true)
+            var command = FluentCommand<string>.Do(param => executeCalled = true, _viewModel)
                 .If(param => false); // CanExecute always returns false
 
             // Act
@@ -36,7 +42,7 @@
         public void CanExecute_WhenConditionIsTrue_ReturnsTrue()
         {
             // Arrange
-            var command = Command<string>.Do(param => { })
+            var command = FluentCommand<string>.Do(param => { }, _viewModel)
                 .If(param => true); // CanExecute always returns true
 
             // Act
@@ -50,7 +56,7 @@
         public void CanExecute_WhenConditionIsFalse_ReturnsFalse()
         {
             // Arrange
-            var command = Command<string>.Do(param => { })
+            var command = FluentCommand<string>.Do(param => { }, _viewModel)
                 .If(param => false); // CanExecute always returns false
 
             // Act
@@ -64,7 +70,7 @@
         public void CanExecute_WhenNotSet_ReturnsTrue()
         {
             // Arrange
-            var command = Command<string>.Do(param => { });
+            var command = FluentCommand<string>.Do(param => { }, _viewModel);
 
             // Act
             var result = command.CanExecute("test");

--- a/src/MVVMFluent.Tests/ViewModelBasePropertiesTests.cs
+++ b/src/MVVMFluent.Tests/ViewModelBasePropertiesTests.cs
@@ -114,7 +114,7 @@ internal class PropertyTestViewModel : ViewModelBase
     {
         get => Get<string?>();
         set => When(value)
-            .OnChanged(newValue => OnChangedAction?.Invoke(newValue))
+            .Changed(newValue => OnChangedAction?.Invoke(newValue))
             .Set();
     }
 
@@ -122,7 +122,7 @@ internal class PropertyTestViewModel : ViewModelBase
     {
         get => Get<string?>();
         set => When(value)
-            .OnChanging(newValue => OnChangingAction?.Invoke(newValue))
+            .Changing(newValue => OnChangingAction?.Invoke(newValue))
             .Set();
     }
 

--- a/src/MVVMFluent.WPF/CommandValidationExtensions.cs
+++ b/src/MVVMFluent.WPF/CommandValidationExtensions.cs
@@ -9,7 +9,7 @@
         /// <param name="propertyName">The name of the property to check for errors.</param>
         /// <returns>The command with the condition added.</returns>
         /// <exception cref="global::System.ArgumentNullException">Thrown when the property name is null or empty.</exception>
-        public static Command IfValid(this Command command, params string[] propertyName)
+        public static FluentCommand IfValid(this FluentCommand command, params string[] propertyName)
         {
             if (command.IsBuilt)
                 return command;
@@ -28,7 +28,7 @@
         /// <param name="propertyName">The name of the property to check for errors.</param>
         /// <returns>The command with the condition added.</returns>
         /// <exception cref="global::System.ArgumentNullException">Thrown when the property name is null or empty.</exception>
-        public static Command<T> IfValid<T>(this Command<T> command, params string[] propertyName)
+        public static FluentCommand<T> IfValid<T>(this FluentCommand<T> command, params string[] propertyName)
         {
             if (command.IsBuilt)
                 return command;

--- a/src/MVVMFluent.WPF/MVVMFluent.WPF.csproj
+++ b/src/MVVMFluent.WPF/MVVMFluent.WPF.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <NuSpecFile>MVVMFluent.WPF.nuspec</NuSpecFile>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>
 

--- a/src/MVVMFluent.WPF/MVVMFluent.WPF.nuspec
+++ b/src/MVVMFluent.WPF/MVVMFluent.WPF.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/kristoffer-tungland/MVVMFluent</projectUrl>
     <description>MVVMFluent WPF is a lightweight, source-only .NET library designed to simplify the MVVM pattern through fluent command and property setter APIs. It reduces boilerplate code in view models, making your codebase cleaner, more readable, and easier to maintain.</description>
     <tags>MVVM source-only Fluent</tags>
-
+    <readme>docs\README.md</readme>
     <dependencies>
         <dependency id="MVVMFluent" version="$version$" include="contentFiles, build" />
     </dependencies>
@@ -22,5 +22,6 @@
     <file src="*.cs" target="contentFiles/cs/net48/MVVMFluent.WPF/"/>
     <!-- 👇 Hide content files from Visual Studio solution explorer  -->
     <file src="MVVMFluent.WPF.props" target="build/MVVMFluent.WPF.props" />
+    <file src="..\..\README.md" target="docs/" />
   </files>
 </package>

--- a/src/MVVMFluent.WPF/ValidationViewModelBase.cs
+++ b/src/MVVMFluent.WPF/ValidationViewModelBase.cs
@@ -15,8 +15,8 @@ namespace MVVMFluent.WPF
     ///         set => When(value).Required().Set();
     ///     }
     ///     
-    ///     // Command
-    ///     public Command Ok => Do(() => MessageBox.Show(Input)).If(() => !string.IsNullOrWhiteSpace(Input));
+    ///     // FluentCommand
+    ///     public FluentCommand Ok => Do(() => MessageBox.Show(Input)).If(() => !string.IsNullOrWhiteSpace(Input));
     /// }
     /// </code>
     /// </example>

--- a/src/MVVMFluent/AsyncCommand.cs
+++ b/src/MVVMFluent/AsyncCommand.cs
@@ -28,7 +28,7 @@
         /// <summary>
         /// Gets the command to cancel the current operation.
         /// </summary>
-        Command CancelCommand { get; }
+        FluentCommand CancelCommand { get; }
 
         /// <summary>
         /// Indicates whether the command is requested to be cancelled.
@@ -61,9 +61,9 @@
     /// public bool CanOk { get => Get(true); set => Set(value); }
     /// </code>
     /// <code lang="xaml">
-    /// &lt;Button Content=&quot;Run&quot; Command=&quot;{Binding AsyncCommand}&quot; /&gt;
+    /// &lt;Button Content=&quot;Run&quot; FluentCommand=&quot;{Binding AsyncCommand}&quot; /&gt;
     /// &lt;ProgressBar Visibility = &quot;{Binding AsyncCommand.IsRunning, Converter={StaticResource BoolToVisibilityConverter}}&quot; /&gt;
-    /// &lt;Button Content=&quot;Cancel&quot; Command=&quot;{Binding AsyncCommand.CancelCommand}&quot; /&gt;
+    /// &lt;Button Content=&quot;Cancel&quot; FluentCommand=&quot;{Binding AsyncCommand.CancelCommand}&quot; /&gt;
     /// </code>
     /// </example>
     /// </summary>
@@ -76,7 +76,7 @@
         private global::System.Action<global::System.Exception>? _onException;
         private bool _continueOnCapturedContext = true;
         private bool _disposed;
-        private Command? _cancelCommand;
+        private FluentCommand? _cancelCommand;
         private int _progress = 0;
         public IFluentSetterViewModel? Owner { get; private set; }
 
@@ -105,13 +105,13 @@
         /// <summary>
         /// Gets the command to cancel the current operation.
         /// </summary>
-        public Command CancelCommand
+        public FluentCommand CancelCommand
         {
             get
             {
                 if (_cancelCommand == null)
                 {
-                    _cancelCommand = Command.Do(() => Cancel(), Owner).If(() => IsRunning && _cts?.IsCancellationRequested == false);
+                    _cancelCommand = FluentCommand.Do(() => Cancel(), Owner).If(() => IsRunning && _cts?.IsCancellationRequested == false);
                     PropertyChanged += (s, e) => _cancelCommand.RaiseCanExecuteChanged();
                 }
                 return _cancelCommand;
@@ -400,9 +400,9 @@
     /// public bool CanOk { get => Get(true); set => Set(value); }
     /// </code>
     /// <code lang="xaml">
-    /// &lt;Button Content=&quot;Run&quot; Command=&quot;{Binding AsyncCommand}&quot; /&gt;
+    /// &lt;Button Content=&quot;Run&quot; FluentCommand=&quot;{Binding AsyncCommand}&quot; /&gt;
     /// &lt;ProgressBar Visibility = &quot;{Binding AsyncCommand.IsRunning, Converter={StaticResource BoolToVisibilityConverter}}&quot; /&gt;
-    /// &lt;Button Content=&quot;Cancel&quot; Command=&quot;{Binding AsyncCommand.CancelCommand}&quot; /&gt;
+    /// &lt;Button Content=&quot;Cancel&quot; FluentCommand=&quot;{Binding AsyncCommand.CancelCommand}&quot; /&gt;
     /// </code>
     /// </example>
     /// </summary>
@@ -415,7 +415,7 @@
         private global::System.Action<global::System.Exception>? _onException;
         private bool _continueOnCapturedContext = true;
         private bool _disposed;
-        private Command? _cancelCommand;
+        private FluentCommand? _cancelCommand;
         private int _progress = 0;
         public IFluentSetterViewModel? Owner { get; private set; }
 
@@ -444,13 +444,13 @@
         /// <summary>
         /// Gets the command to cancel the current operation.
         /// </summary>
-        public Command CancelCommand
+        public FluentCommand CancelCommand
         {
             get
             {
                 if (_cancelCommand == null)
                 {
-                    _cancelCommand = Command.Do(() => Cancel(), Owner).If(() => IsRunning && _cts?.IsCancellationRequested == false);
+                    _cancelCommand = FluentCommand.Do(() => Cancel(), Owner).If(() => IsRunning && _cts?.IsCancellationRequested == false);
                     PropertyChanged += (s, e) => _cancelCommand.RaiseCanExecuteChanged();
                 }
                 return _cancelCommand;

--- a/src/MVVMFluent/FluentCommand.cs
+++ b/src/MVVMFluent/FluentCommand.cs
@@ -12,13 +12,13 @@
     /// Represents a command that can be executed and has an associated execution condition.
     /// <example>
     /// <code lang="csharp">
-    /// public Command OkCommand => Do(() => MessageBox.Show("OK")).If(() => CanOk);
+    /// public FluentCommand OkCommand => Do(() => MessageBox.Show("OK")).If(() => CanOk);
     /// 
     /// public bool CanOk { get => Get(true); set => Set(value); }
     /// </code>
     /// </example>
     /// </summary>
-    public class Command : IFluentCommand, global::System.IDisposable
+    public class FluentCommand : IFluentCommand, global::System.IDisposable
     {
         private global::System.Action<object?>? _execute;
         private global::System.Func<object, bool>? _canExecute;
@@ -34,7 +34,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Command"/> class with the specified execute action.
+        /// Initializes a new instance of the <see cref="FluentCommand"/> class with the specified execute action.
         /// </summary>
         protected void SetCommand(global::System.Action<object?> execute)
         {
@@ -47,23 +47,23 @@
         public event global::System.EventHandler? CanExecuteChanged;
 
         /// <summary>
-        /// Creates a new <see cref="Command"/> instance with the specified action.
+        /// Creates a new <see cref="FluentCommand"/> instance with the specified action.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <returns>A new <see cref="Command"/> instance.</returns>
-        public static Command Do(global::System.Action execute, IFluentSetterViewModel? owner)
+        /// <returns>A new <see cref="FluentCommand"/> instance.</returns>
+        public static FluentCommand Do(global::System.Action execute, IFluentSetterViewModel? owner)
         {
             return Do(_ => execute(), owner);
         }
 
         /// <summary>
-        /// Creates a new <see cref="Command"/> instance with the specified action.
+        /// Creates a new <see cref="FluentCommand"/> instance with the specified action.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <returns>A new <see cref="Command"/> instance.</returns>
-        public static Command Do(global::System.Action<object?> execute, IFluentSetterViewModel? owner)
+        /// <returns>A new <see cref="FluentCommand"/> instance.</returns>
+        public static FluentCommand Do(global::System.Action<object?> execute, IFluentSetterViewModel? owner)
         {
-            var command = new Command();
+            var command = new FluentCommand();
             command.Owner = owner;
             command.SetCommand(execute);
             return command;
@@ -73,8 +73,8 @@
         /// Sets the condition under which the command can execute.
         /// </summary>
         /// <param name="canExecute">A function that determines if the command can execute.</param>
-        /// <returns>The current <see cref="Command"/> instance.</returns>
-        public Command If(global::System.Func<bool> canExecute)
+        /// <returns>The current <see cref="FluentCommand"/> instance.</returns>
+        public FluentCommand If(global::System.Func<bool> canExecute)
         {
             return If(_ => canExecute());
         }
@@ -83,8 +83,8 @@
         /// Sets the condition under which the command can execute.
         /// </summary>
         /// <param name="canExecute">A function that determines if the command can execute based on the provided parameter.</param>
-        /// <returns>The current <see cref="Command"/> instance.</returns>
-        public Command If(global::System.Func<object, bool> canExecute)
+        /// <returns>The current <see cref="FluentCommand"/> instance.</returns>
+        public FluentCommand If(global::System.Func<object, bool> canExecute)
         {
             if (IsBuilt)
                 return this;
@@ -119,7 +119,7 @@
         public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, global::System.EventArgs.Empty);
 
         /// <summary>
-        /// Releases all resources used by the <see cref="Command"/> instance.
+        /// Releases all resources used by the <see cref="FluentCommand"/> instance.
         /// </summary>
         public void Dispose()
         {
@@ -150,9 +150,9 @@
         }
 
         /// <summary>
-        /// Finalizer for the <see cref="Command"/> class.
+        /// Finalizer for the <see cref="FluentCommand"/> class.
         /// </summary>
-        ~Command()
+        ~FluentCommand()
         {
             Dispose(false);
         }
@@ -162,14 +162,14 @@
     /// Represents a command that can be executed with a parameter of type <typeparamref name="T"/>.
     /// <example>
     /// <code lang="csharp">
-    /// public Command OkCommand => Do&lt;string&gt;(str => MessageBox.Show(str)).If(str => CanOk(str));
+    /// public FluentCommand OkCommand => Do&lt;string&gt;(str => MessageBox.Show(str)).If(str => CanOk(str));
     /// 
     /// public bool CanOk(string str) => !string.IsNullOrWhiteSpace(str);
     /// </code>
     /// </example>
     /// </summary>
     /// <typeparam name="T">The type of the parameter used by the command.</typeparam>
-    public class Command<T> : IFluentCommand, global::System.IDisposable
+    public class FluentCommand<T> : IFluentCommand, global::System.IDisposable
     {
         private global::System.Action<T>? _execute;
         private global::System.Func<T, bool>? _canExecute;
@@ -183,7 +183,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Command{T}"/> class with the specified execute action.
+        /// Initializes a new instance of the <see cref="FluentCommand{T}"/> class with the specified execute action.
         /// </summary>
         /// <param name="execute">The action to execute when the command is invoked.</param>
         protected void SetCommand(global::System.Action<T> execute)
@@ -200,10 +200,10 @@
         /// Creates a new command with the specified execute action.
         /// </summary>
         /// <param name="execute">The action to execute when the command is invoked.</param>
-        /// <returns>A new instance of <see cref="Command{T}"/>.</returns>
-        public static Command<T> Do(global::System.Action<T> execute, IFluentSetterViewModel? owner)
+        /// <returns>A new instance of <see cref="FluentCommand{T}"/>.</returns>
+        public static FluentCommand<T> Do(global::System.Action<T> execute, IFluentSetterViewModel? owner)
         {
-            var command = new Command<T>
+            var command = new FluentCommand<T>
             {
                 Owner = owner
             };
@@ -215,8 +215,8 @@
         /// Configures the command to determine whether it can execute based on a condition.
         /// </summary>
         /// <param name="canExecute">A function that returns a boolean indicating whether the command can execute.</param>
-        /// <returns>The current <see cref="Command{T}"/> instance for fluent chaining.</returns>
-        public Command<T> If(global::System.Func<bool> canExecute)
+        /// <returns>The current <see cref="FluentCommand{T}"/> instance for fluent chaining.</returns>
+        public FluentCommand<T> If(global::System.Func<bool> canExecute)
         {
             return If(_ => canExecute());
         }
@@ -225,8 +225,8 @@
         /// Configures the command to determine whether it can execute based on a condition that uses a parameter.
         /// </summary>
         /// <param name="canExecute">A function that determines whether the command can execute based on the provided parameter.</param>
-        /// <returns>The current <see cref="Command{T}"/> instance for fluent chaining.</returns>
-        public Command<T> If(global::System.Func<T, bool> canExecute)
+        /// <returns>The current <see cref="FluentCommand{T}"/> instance for fluent chaining.</returns>
+        public FluentCommand<T> If(global::System.Func<T, bool> canExecute)
         {
             if (IsBuilt)
                 return this;
@@ -261,7 +261,7 @@
         public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, global::System.EventArgs.Empty);
 
         /// <summary>
-        /// Releases all resources used by the <see cref="Command{T}"/> instance.
+        /// Releases all resources used by the <see cref="FluentCommand{T}"/> instance.
         /// </summary>
         public void Dispose()
         {
@@ -270,7 +270,7 @@
         }
 
         /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="Command{T}"/> instance and optionally releases the managed resources.
+        /// Releases the unmanaged resources used by the <see cref="FluentCommand{T}"/> instance and optionally releases the managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
@@ -292,9 +292,9 @@
         }
 
         /// <summary>
-        /// Finalizer for the <see cref="Command{T}"/> class.
+        /// Finalizer for the <see cref="FluentCommand{T}"/> class.
         /// </summary>
-        ~Command()
+        ~FluentCommand()
         {
             Dispose(false);
         }

--- a/src/MVVMFluent/FluentSetterViewModelBase.cs
+++ b/src/MVVMFluent/FluentSetterViewModelBase.cs
@@ -98,7 +98,7 @@
         /// Creates a command that can execute the specified action.
         /// <example>
         /// <code lang="csharp">
-        /// public Command OkCommand => Do(() => MessageBox.Show("OK")).If(() => CanOk);
+        /// public FluentCommand OkCommand => Do(() => MessageBox.Show("OK")).If(() => CanOk);
         /// 
         /// public bool CanOk { get => Get(true); set => Set(value); }
         /// </code>
@@ -106,10 +106,10 @@
         /// </summary>
         /// <param name="execute">The action to execute.</param>
         /// <param name="propertyName">The name of the property associated with the command.</param>
-        /// <returns>A new <see cref="Command"/> instance.</returns>
+        /// <returns>A new <see cref="FluentCommand"/> instance.</returns>
         /// <exception cref="global::System.ArgumentNullException">Thrown when the property name is null or empty.</exception>
         /// <exception cref="global::System.ArgumentException">Thrown when the property name is .ctor.</exception>
-        protected Command Do(global::System.Action execute, [global::System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+        protected FluentCommand Do(global::System.Action execute, [global::System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
         {
             return Do(_ => execute(), propertyName);
         }
@@ -118,7 +118,7 @@
         /// Creates a command that can execute the specified action with a parameter.
         /// <example>
         /// <code lang="csharp">
-        /// public Command OkCommand => Do&lt;string&gt;(str => MessageBox.Show(str)).If(str => CanOk(str));
+        /// public FluentCommand OkCommand => Do&lt;string&gt;(str => MessageBox.Show(str)).If(str => CanOk(str));
         /// 
         /// public bool CanOk(string str) => !string.IsNullOrWhiteSpace(str);
         /// </code>
@@ -127,61 +127,61 @@
         /// <typeparam name="TValue">The type of the parameter for the command.</typeparam>
         /// <param name="execute">The action to execute.</param>
         /// <param name="propertyName">The name of the property associated with the command.</param>
-        /// <returns>Returns a new <see cref="Command{TValue}"/> instance.</returns>
+        /// <returns>Returns a new <see cref="FluentCommand{TValue}"/> instance.</returns>
         /// <exception cref="global::System.ArgumentNullException">Thrown when the property name is null or empty.</exception>
         /// <exception cref="global::System.ArgumentException">Thrown when the property name is .ctor.</exception>
-        protected Command<TValue> Do<TValue>(global::System.Action<TValue> execute, [global::System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+        protected FluentCommand<TValue> Do<TValue>(global::System.Action<TValue> execute, [global::System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
         {
             if (propertyName == null)
                 throw new global::System.ArgumentNullException(nameof(propertyName), "Not able to determine property name to set.");
 
             // Error handling when property name is .ctor
             if (propertyName == ".ctor")
-                throw new global::System.ArgumentException(nameof(propertyName), "Command name must be provided when it is created in the constructor.");
+                throw new global::System.ArgumentException(nameof(propertyName), "FluentCommand name must be provided when it is created in the constructor.");
 
             if (!_commandStore.TryGetValue(propertyName, out var command))
             {
-                command = Command<TValue>.Do(execute, this);
+                command = FluentCommand<TValue>.Do(execute, this);
                 _commandStore.Add(propertyName, command);
             }
             else
                 command.MarkAsBuilt();
 
-            return (Command<TValue>)command;
+            return (FluentCommand<TValue>)command;
         }
 
         /// <summary>
         /// Creates a command that can execute the specified action with a parameter.
         /// <example>
         /// <code lang="csharp">
-        /// public Command OkCommand => Do(obj => MessageBox.Show(obj.ToString()));
+        /// public FluentCommand OkCommand => Do(obj => MessageBox.Show(obj.ToString()));
         /// </code>
         /// </example>
         /// </summary>
         /// <remarks>Use generic version for type safety.</remarks>
         /// <param name="execute">The action to execute. The parameter is of type object.</param>
         /// <param name="propertyName">The name of the property associated with the command.</param>
-        /// <returns>Returns a new <see cref="Command"/> instance.</returns>
+        /// <returns>Returns a new <see cref="FluentCommand"/> instance.</returns>
         /// <exception cref="global::System.ArgumentNullException">Thrown when the property name is null or empty.</exception>
         /// <exception cref="global::System.ArgumentException">Thrown when the property name is .ctor.</exception>
-        protected Command Do(global::System.Action<object?> execute, [global::System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+        protected FluentCommand Do(global::System.Action<object?> execute, [global::System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
         {
             if (propertyName == null)
                 throw new global::System.ArgumentNullException(nameof(propertyName), "Not able to determine property name to set.");
 
             // Error handling when property name is .ctor
             if (propertyName == ".ctor")
-                throw new global::System.ArgumentException(nameof(propertyName), "Command name must be provided when it is created in the constructor.");
+                throw new global::System.ArgumentException(nameof(propertyName), "FluentCommand name must be provided when it is created in the constructor.");
 
             if (!_commandStore.TryGetValue(propertyName, out var command))
             {
-                command = Command.Do(execute, this);
+                command = FluentCommand.Do(execute, this);
                 _commandStore.Add(propertyName, command);
             }
             else
                 command.MarkAsBuilt();
 
-            return (Command)command;
+            return (FluentCommand)command;
         }
 
         /// <summary>
@@ -193,9 +193,9 @@
         /// public bool CanOk { get => Get(true); set => Set(value); }
         /// </code>
         /// <code lang="xaml">
-        /// &lt;Button Content=&quot;Run&quot; Command=&quot;{Binding AsyncCommand}&quot; /&gt;
+        /// &lt;Button Content=&quot;Run&quot; FluentCommand=&quot;{Binding AsyncCommand}&quot; /&gt;
         /// &lt;ProgressBar Visibility = &quot;{Binding AsyncCommand.IsRunning, Converter={StaticResource BoolToVisibilityConverter}}&quot; /&gt;
-        /// &lt;Button Content=&quot;Cancel&quot; Command=&quot;{Binding AsyncCommand.CancelCommand}&quot; /&gt;
+        /// &lt;Button Content=&quot;Cancel&quot; FluentCommand=&quot;{Binding AsyncCommand.CancelCommand}&quot; /&gt;
         /// </code>
         /// </example>
         /// </summary>
@@ -242,7 +242,7 @@
         /// public AsyncCommand OkCommand => Do(async () => await Task.Delay(1000)).If(() => CanOk);
         /// </code>
         /// <code lang="csharp">
-        /// // Command with all options
+        /// // FluentCommand with all options
         /// public AsyncCommand&lt;string&gt; OkCommand => Do&lt;string&gt;(str => Task.Delay(1000).ContinueWith(_ => MessageBox.Show(str))).If(str => CanOk(str)).Handle(ex => MessageBox.Show(ex.Message)).ConfigureAwait(false);
         /// </code>
         /// </example>
@@ -281,7 +281,7 @@
 
             // Error handling when property name is .ctor
             if (propertyName == ".ctor")
-                throw new global::System.ArgumentException(nameof(propertyName), "Command name must be provided when it is created in the constructor.");
+                throw new global::System.ArgumentException(nameof(propertyName), "FluentCommand name must be provided when it is created in the constructor.");
 
             if (!_commandStore.TryGetValue(propertyName, out var command))
             {
@@ -336,7 +336,7 @@
 
             // Error handling when property name is .ctor
             if (propertyName == ".ctor")
-                throw new global::System.ArgumentException(nameof(propertyName), "Command name must be provided when it is created in the constructor.");
+                throw new global::System.ArgumentException(nameof(propertyName), "FluentCommand name must be provided when it is created in the constructor.");
 
             if (!_commandStore.TryGetValue(propertyName, out var command))
             {

--- a/src/MVVMFluent/MVVMFluent.csproj
+++ b/src/MVVMFluent/MVVMFluent.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NuSpecFile>MVVMFluent.nuspec</NuSpecFile>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>
     

--- a/src/MVVMFluent/MVVMFluent.nuspec
+++ b/src/MVVMFluent/MVVMFluent.nuspec
@@ -11,10 +11,12 @@
     <projectUrl>https://github.com/kristoffer-tungland/MVVMFluent</projectUrl>
     <description>MVVMFluent is a lightweight, source-only .NET library designed to simplify the MVVM pattern through fluent command and property setter APIs. It reduces boilerplate code in view models, making your codebase cleaner, more readable, and easier to maintain.</description>
     <tags>MVVM WPF source-only Fluent</tags>
+    <readme>docs\README.md</readme>
   </metadata>
   <files>
     <file src="*.cs" target="contentFiles/cs/netstandard2.0/MVVMFluent/"/>
      <!-- 👇 Hide content files from Visual Studio solution explorer -->  
     <file src="MVVMFluent.props" target="build/MVVMFluent.props" />
+    <file src="..\..\README.md" target="docs/" />
   </files>
 </package>

--- a/src/MVVMFluent/ViewModelBase.cs
+++ b/src/MVVMFluent/ViewModelBase.cs
@@ -12,8 +12,8 @@
     ///     // Property that notifies the Ok command when changed
     ///     public string? Input { get => Get&lt;string?&gt;(); set => When(value).Notify(Ok).Set(); }
     ///     
-    ///     // Command
-    ///     public Command Ok => Do(() => MessageBox.Show(Input)).If(() => !string.IsNullOrWhiteSpace(Input));
+    ///     // FluentCommand
+    ///     public FluentCommand Ok => Do(() => MessageBox.Show(Input)).If(() => !string.IsNullOrWhiteSpace(Input));
     /// }
     /// </code>
     /// </example>


### PR DESCRIPTION
Replaced Command and Command<T> with FluentCommand and FluentCommand<T> across the project. Updated README.md, test cases, and example code to reflect the new naming convention. Incremented project version to 0.0.2. Added new readme reference to the NuGet package specification. Introduced MVVMFluent namespace with IFluentCommand interface and FluentCommand classes.