### PR TITLE
Add Roslyn analyzer to enforce .Set() in fluent setters

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,9 +37,6 @@ jobs:
     - name: Authenticate GitHub Packages
       run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name "github" --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
-    - name: Set API key for GitHub NuGet source
-      run: dotnet nuget setapikey "${{ secrets.GITHUB_TOKEN }}" --source "github"
-
     - name: Restore dependencies
       run: dotnet restore
     
@@ -50,4 +47,4 @@ jobs:
       run: dotnet test --no-build --verbosity normal --configuration Release
 
     - name: Push Package to GitHub
-      run: dotnet nuget push **/*.nupkg --source github --skip-duplicate
+      run: dotnet nuget push **/*.nupkg --source github --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,8 +30,8 @@ jobs:
       with:
         dotnet-version: 8.0.x
     
-    - name: Authenticate nuget feed
-      run: dotnet nuget add source --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+    - name: Authenticate GitHub Packages
+      run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name "github" --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
     - name: Restore dependencies
       run: dotnet restore
@@ -43,4 +43,4 @@ jobs:
       run: dotnet test --no-build --verbosity normal --configuration Release
 
     - name: Push Package to GitHub
-      run: nuget push **\*.nupkg -Source github -SkipDuplicate
+      run: dotnet nuget push **/*.nupkg --source github --skip-duplicate

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
 
@@ -32,6 +36,9 @@ jobs:
     
     - name: Authenticate GitHub Packages
       run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name "github" --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+    - name: Set API key for GitHub NuGet source
+      run: dotnet nuget setapikey "${{ secrets.GITHUB_TOKEN }}" --source "github"
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/onPushMaster.yml
+++ b/.github/workflows/onPushMaster.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
 
@@ -17,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-          fetch-depth: 0
+        fetch-depth: 0
 
     - name: Application Version
       id: version
@@ -31,8 +35,8 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
-    - name: Authenticate nuget feed
-      run: dotnet nuget add source --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+    - name: Authenticate GitHub Packages
+      run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name "github" --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
     - name: Restore dependencies
       run: dotnet restore
@@ -44,7 +48,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal --configuration Release
     
     - name: Push Package to NuGet.org
-      run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
+      run: dotnet nuget push **/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key "${{ secrets.NUGET_API_KEY }}" --skip-duplicate
 
     - id: "release"
       name: "Automatic Release"
@@ -57,7 +61,7 @@ jobs:
         files: |
           LICENSE.txt
           README.md
-          **\*.nupkg
+          **/*.nupkg
 
     - name: Push Package to GitHub
-      run: nuget push **\*.nupkg -Source github -SkipDuplicate
+      run: dotnet nuget push **/*.nupkg --source github --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate

--- a/MVVMFluent.sln
+++ b/MVVMFluent.sln
@@ -20,6 +20,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MVVMFluent.WPF", "src\MVVMF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MVVMFluent.ValidationExtensions", "src\MVVMFluent.ValidationExtensions\MVVMFluent.ValidationExtensions.csproj", "{4ED1E77F-98CC-4856-AFE3-468BB0758363}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MVVMFluent.Analyzers", "src\MVVMFluent.Analyzers\MVVMFluent.Analyzers.csproj", "{8346988E-D195-C7ED-BC95-6DD0BF9A7ECC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{CE947AFD-0D70-469B-B125-8D80678D7D9E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MVVMFluent.Analyzers.Tests", "src\MVVMFluent.Analyzers.Tests\MVVMFluent.Analyzers.Tests.csproj", "{A53A2F77-5FB2-7C06-3953-F0996B21EAD8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,9 +52,21 @@ Global
 		{4ED1E77F-98CC-4856-AFE3-468BB0758363}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4ED1E77F-98CC-4856-AFE3-468BB0758363}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4ED1E77F-98CC-4856-AFE3-468BB0758363}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8346988E-D195-C7ED-BC95-6DD0BF9A7ECC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8346988E-D195-C7ED-BC95-6DD0BF9A7ECC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8346988E-D195-C7ED-BC95-6DD0BF9A7ECC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8346988E-D195-C7ED-BC95-6DD0BF9A7ECC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A53A2F77-5FB2-7C06-3953-F0996B21EAD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A53A2F77-5FB2-7C06-3953-F0996B21EAD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A53A2F77-5FB2-7C06-3953-F0996B21EAD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A53A2F77-5FB2-7C06-3953-F0996B21EAD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FC09FBAC-54B2-4567-80B9-39CC77E5422D} = {CE947AFD-0D70-469B-B125-8D80678D7D9E}
+		{A53A2F77-5FB2-7C06-3953-F0996B21EAD8} = {CE947AFD-0D70-469B-B125-8D80678D7D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0140A73B-37AC-4055-934A-9076B1A07301}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ MVVMFluent is a lightweight .NET library that helps you build MVVM view models w
 - **Async command support** &mdash; Use `IAsyncFluentCommand` / `IAsyncFluentCommand<T>` to handle cancellable asynchronous work, expose an auto-wired `CancelCommand`, and surface progress updates through `INotifyPropertyChanged`.
 - **Validation pipeline** &mdash; Opt-in to `ValidationViewModelBase` to compose validation rules (such as `HasValue` or custom `Validate` callbacks) that keep the `Errors` collection and `HasErrors` flag in sync with your UI.
 - **Extended validation helpers** &mdash; Reference `MVVMFluent.ValidationExtensions` for ready-to-use rules like `IsEmail`, `IsUrl`, `HasLengthBetween`, and date or range guards.
+- **Roslyn analyzer** &mdash; Automatically included analyzer that enforces proper usage of `.Set()` at the end of fluent setter chains to prevent subtle bugs.
 - **Deterministic cleanup** &mdash; View model, command, and builder implementations implement `IDisposable` where appropriate to avoid self-referencing leaks when commands are re-evaluated or builders are cached.
 
 ## Installation
@@ -18,7 +19,7 @@ Install the package from NuGet just like any other binary dependency:
 dotnet add package MVVMFluent
 ```
 
-The package embeds the project README and license so IDE package managers surface the latest documentation.
+The package embeds the project README and license so IDE package managers surface the latest documentation. A Roslyn analyzer is automatically included to help enforce proper usage patterns.
 
 ## Architecture
 
@@ -215,6 +216,40 @@ public class ContactViewModel : ValidationViewModelBase
 
 The extensions enforce that the owning view model derives from `ValidationViewModelBase` and throw meaningful exceptions when the
 validated properties are missing or contain errors.
+
+## Roslyn Analyzer
+
+MVVMFluent includes a Roslyn analyzer that enforces proper usage of fluent property setters. The analyzer ensures that every property setter using `When(value)` ends with a call to `.Set()`, which is crucial for committing values to the backing field and triggering property change notifications.
+
+### MVVMFLUENT001: Fluent setter must end with Set()
+
+**Severity**: Error
+
+**What it does**: Detects property setters that use `When(value)` but don't end with `.Set()`.
+
+**Why it matters**: Without `.Set()`, the value isn't committed to the backing field, and property change notifications aren't triggered, leading to subtle bugs where the UI doesn't update or validation doesn't run.
+
+**Example of violation**:
+```csharp
+public string Name
+{
+    get => Get<string>();
+    set => When(value).Validate(); // ? Error: Missing Set()!
+}
+```
+
+**Correct usage**:
+```csharp
+public string Name
+{
+    get => Get<string>();
+    set => When(value).Validate().Set(); // ? Correct
+}
+```
+
+**Code fix**: The analyzer includes an automatic code fix. Simply press `Ctrl+.` (or `Cmd+.` on Mac) when the error appears and select "Add .Set() to complete fluent setter" to automatically append `.Set()` to your fluent chain.
+
+The analyzer works with both `ViewModelBase` and `ValidationViewModelBase`, and supports both expression-bodied and block-bodied setters.
 
 ## API Design
 

--- a/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetAnalyzerTests.cs
+++ b/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetAnalyzerTests.cs
@@ -94,13 +94,13 @@ public class TestViewModel : ViewModelBase
     public string Name
     {
         get => Get<string>() ?? string.Empty;
-        set => {|#0:When(value)|};
+        set => When(value);
     }
 }";
 
         var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(9, 16, 9, 27)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
@@ -117,13 +117,13 @@ public class TestViewModel : ValidationViewModelBase
     public string Email
     {
         get => Get<string>() ?? string.Empty;
-        set => {|#0:When(value).HasValue(""Email is required"")|};
+        set => When(value).HasValue(""Email is required"");
     }
 }";
 
         var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(9, 16, 9, 57)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
@@ -140,15 +140,15 @@ public class TestViewModel : ViewModelBase
     public string Name
     {
         get => Get<string>() ?? string.Empty;
-        set => {|#0:When(value)
+        set => When(value)
             .Changing(() => System.Console.WriteLine(""Changing""))
-            .Changed(() => System.Console.WriteLine(""Changed""))|};
+            .Changed(() => System.Console.WriteLine(""Changed""));
     }
 }";
 
         var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(9, 16, 11, 64)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
@@ -167,14 +167,14 @@ public class TestViewModel : ViewModelBase
         get => Get<string>() ?? string.Empty;
         set
         {
-            {|#0:When(value).Changing(() => System.Console.WriteLine(""Changing""))|};
+            When(value).Changing(() => System.Console.WriteLine(""Changing""));
         }
     }
 }";
 
         var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(11, 13, 11, 78)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);

--- a/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetAnalyzerTests.cs
+++ b/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetAnalyzerTests.cs
@@ -1,0 +1,203 @@
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MVVMFluent.Analyzers.Tests;
+
+public class FluentSetterMustEndWithSetAnalyzerTests
+{
+    [Fact]
+    public async Task NoDiagnostic_WhenSetterDoesNotUseWhen()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    private string _name = string.Empty;
+    
+    public string Name
+    {
+        get => _name;
+        set { _name = value; }
+    }
+}";
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenWhenEndsWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => When(value).Set();
+    }
+}";
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenWhenWithValidationEndsWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ValidationViewModelBase
+{
+    public string Email
+    {
+        get => Get<string>() ?? string.Empty;
+        set => When(value).HasValue(""Email is required"").Set();
+    }
+}";
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenWhenWithChainedMethodsEndsWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => When(value)
+            .Changing(() => System.Console.WriteLine(""Changing""))
+            .Changed(() => System.Console.WriteLine(""Changed""))
+            .Set();
+    }
+}";
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Diagnostic_WhenWhenDoesNotEndWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => {|#0:When(value)|};
+    }
+}";
+
+        var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Diagnostic_WhenWhenWithValidationDoesNotEndWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ValidationViewModelBase
+{
+    public string Email
+    {
+        get => Get<string>() ?? string.Empty;
+        set => {|#0:When(value).HasValue(""Email is required"")|};
+    }
+}";
+
+        var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Diagnostic_WhenWhenWithChainedMethodsDoesNotEndWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => {|#0:When(value)
+            .Changing(() => System.Console.WriteLine(""Changing""))
+            .Changed(() => System.Console.WriteLine(""Changed""))|};
+    }
+}";
+
+        var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Diagnostic_WhenWhenInBlockBodyDoesNotEndWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set
+        {
+            {|#0:When(value).Changing(() => System.Console.WriteLine(""Changing""))|};
+        }
+    }
+}";
+
+        var expected = CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenWhenInBlockBodyEndsWithSet()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set
+        {
+            When(value).Changing(() => System.Console.WriteLine(""Changing"")).Set();
+        }
+    }
+}";
+
+        await CSharpAnalyzerVerifier<FluentSetterMustEndWithSetAnalyzer>.VerifyAnalyzerAsync(test);
+    }
+}

--- a/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetCodeFixTests.cs
+++ b/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetCodeFixTests.cs
@@ -17,7 +17,7 @@ public class TestViewModel : ViewModelBase
     public string Name
     {
         get => Get<string>() ?? string.Empty;
-        set => {|#0:When(value)|};
+        set => When(value);
     }
 }";
 
@@ -35,7 +35,7 @@ public class TestViewModel : ViewModelBase
 
         var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(9, 16, 9, 27)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
@@ -53,7 +53,7 @@ public class TestViewModel : ValidationViewModelBase
     public string Email
     {
         get => Get<string>() ?? string.Empty;
-        set => {|#0:When(value).HasValue(""Email is required"")|};
+        set => When(value).HasValue(""Email is required"");
     }
 }";
 
@@ -71,7 +71,7 @@ public class TestViewModel : ValidationViewModelBase
 
         var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(9, 16, 9, 57)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
@@ -89,9 +89,9 @@ public class TestViewModel : ViewModelBase
     public string Name
     {
         get => Get<string>() ?? string.Empty;
-        set => {|#0:When(value)
+        set => When(value)
             .Changing(() => System.Console.WriteLine(""Changing""))
-            .Changed(() => System.Console.WriteLine(""Changed""))|};
+            .Changed(() => System.Console.WriteLine(""Changed""));
     }
 }";
 
@@ -111,7 +111,7 @@ public class TestViewModel : ViewModelBase
 
         var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(9, 16, 11, 64)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
@@ -131,7 +131,7 @@ public class TestViewModel : ViewModelBase
         get => Get<string>() ?? string.Empty;
         set
         {
-            {|#0:When(value).Changing(() => System.Console.WriteLine(""Changing""))|};
+            When(value).Changing(() => System.Console.WriteLine(""Changing""));
         }
     }
 }";
@@ -153,7 +153,7 @@ public class TestViewModel : ViewModelBase
 
         var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
             .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
-            .WithLocation(0)
+            .WithSpan(11, 13, 11, 78)
             .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
 
         await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>

--- a/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetCodeFixTests.cs
+++ b/src/MVVMFluent.Analyzers.Tests/FluentSetterMustEndWithSetCodeFixTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MVVMFluent.Analyzers.Tests;
+
+public class FluentSetterMustEndWithSetCodeFixTests
+{
+    [Fact]
+    public async Task CodeFix_AddsSetToSimpleWhenCall()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => {|#0:When(value)|};
+    }
+}";
+
+        var fixedCode = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => When(value).Set();
+    }
+}";
+
+        var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddsSetToWhenWithValidation()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ValidationViewModelBase
+{
+    public string Email
+    {
+        get => Get<string>() ?? string.Empty;
+        set => {|#0:When(value).HasValue(""Email is required"")|};
+    }
+}";
+
+        var fixedCode = @"
+using MVVMFluent;
+
+public class TestViewModel : ValidationViewModelBase
+{
+    public string Email
+    {
+        get => Get<string>() ?? string.Empty;
+        set => When(value).HasValue(""Email is required"").Set();
+    }
+}";
+
+        var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddsSetToChainedMethods()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => {|#0:When(value)
+            .Changing(() => System.Console.WriteLine(""Changing""))
+            .Changed(() => System.Console.WriteLine(""Changed""))|};
+    }
+}";
+
+        var fixedCode = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set => When(value)
+            .Changing(() => System.Console.WriteLine(""Changing""))
+            .Changed(() => System.Console.WriteLine(""Changed"")).Set();
+    }
+}";
+
+        var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddsSetInBlockBody()
+    {
+        var test = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set
+        {
+            {|#0:When(value).Changing(() => System.Console.WriteLine(""Changing""))|};
+        }
+    }
+}";
+
+        var fixedCode = @"
+using MVVMFluent;
+
+public class TestViewModel : ViewModelBase
+{
+    public string Name
+    {
+        get => Get<string>() ?? string.Empty;
+        set
+        {
+            When(value).Changing(() => System.Console.WriteLine(""Changing"")).Set();
+        }
+    }
+}";
+
+        var expected = CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .Diagnostic(FluentSetterMustEndWithSetAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithMessage("Property setter using 'When(value)' must end with a call to 'Set()' to commit the value");
+
+        await CSharpCodeFixVerifier<FluentSetterMustEndWithSetAnalyzer, FluentSetterMustEndWithSetCodeFixProvider>
+            .VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+}

--- a/src/MVVMFluent.Analyzers.Tests/MVVMFluent.Analyzers.Tests.csproj
+++ b/src/MVVMFluent.Analyzers.Tests/MVVMFluent.Analyzers.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MVVMFluent.Analyzers\MVVMFluent.Analyzers.csproj" />
+    <ProjectReference Include="..\MVVMFluent\MVVMFluent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +11,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
+        => new DiagnosticResult(diagnosticId, DiagnosticSeverity.Error);
 
     public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
@@ -21,7 +20,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
         return test.RunAsync(CancellationToken.None);
     }
 
-    private class Test : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+    private class Test : CSharpAnalyzerTest<TAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>
     {
         public Test()
         {

--- a/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MVVMFluent.Analyzers.Tests;
+
+public static class CSharpAnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
+
+    public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new Test { TestCode = source };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync(CancellationToken.None);
+    }
+
+    private class Test : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+    {
+        public Test()
+        {
+            // Add reference to MVVMFluent to get the ViewModelBase and interfaces
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            TestState.AdditionalReferences.Add(typeof(ViewModelBase).Assembly);
+        }
+    }
+}

--- a/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MVVMFluent.Analyzers.Tests;
+
+public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
+{
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+
+    public static Task VerifyCodeFixAsync(string source, string fixedSource)
+        => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+    public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+        => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+    public static Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    {
+        var test = new Test
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync(CancellationToken.None);
+    }
+
+    private class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+    {
+        public Test()
+        {
+            // Add reference to MVVMFluent to get the ViewModelBase and interfaces
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            TestState.AdditionalReferences.Add(typeof(ViewModelBase).Assembly);
+        }
+    }
+}

--- a/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/MVVMFluent.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,7 +13,7 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TCodeFix : CodeFixProvider, new()
 {
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+        => new DiagnosticResult(diagnosticId, DiagnosticSeverity.Error);
 
     public static Task VerifyCodeFixAsync(string source, string fixedSource)
         => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
@@ -34,7 +33,7 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         return test.RunAsync(CancellationToken.None);
     }
 
-    private class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+    private class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, Microsoft.CodeAnalysis.Testing.DefaultVerifier>
     {
         public Test()
         {

--- a/src/MVVMFluent.Analyzers/FluentSetterMustEndWithSetAnalyzer.cs
+++ b/src/MVVMFluent.Analyzers/FluentSetterMustEndWithSetAnalyzer.cs
@@ -1,0 +1,177 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace MVVMFluent.Analyzers;
+
+/// <summary>
+/// Analyzer that ensures property setters using When(value) always end with a call to Set().
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class FluentSetterMustEndWithSetAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "MVVMFLUENT001";
+    private const string Category = "Usage";
+
+    private static readonly LocalizableString Title = 
+        "Fluent setter must end with Set()";
+    
+    private static readonly LocalizableString MessageFormat = 
+        "Property setter using 'When(value)' must end with a call to 'Set()' to commit the value";
+    
+    private static readonly LocalizableString Description = 
+        "When using the fluent setter pattern with When(value), you must call Set() at the end of the chain to commit the value to the backing field. " +
+        "Without Set(), the value will not be properly stored and property change notifications will not be triggered.";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzePropertySetter, SyntaxKind.SetAccessorDeclaration);
+    }
+
+    private static void AnalyzePropertySetter(SyntaxNodeAnalysisContext context)
+    {
+        var setAccessor = (AccessorDeclarationSyntax)context.Node;
+        
+        // Check if the setter has an expression body (e.g., set => When(value)...)
+        if (setAccessor.ExpressionBody != null)
+        {
+            AnalyzeExpression(context, setAccessor.ExpressionBody.Expression, setAccessor.ExpressionBody.Expression.GetLocation());
+        }
+        // Check if the setter has a block body
+        else if (setAccessor.Body != null)
+        {
+            foreach (var statement in setAccessor.Body.Statements)
+            {
+                if (statement is ExpressionStatementSyntax expressionStatement)
+                {
+                    AnalyzeExpression(context, expressionStatement.Expression, statement.GetLocation());
+                }
+            }
+        }
+    }
+
+    private static void AnalyzeExpression(SyntaxNodeAnalysisContext context, ExpressionSyntax expression, Location location)
+    {
+        // Look for invocation expressions that might be part of a fluent chain
+        if (expression is InvocationExpressionSyntax invocation)
+        {
+            // Check if this is the root of a method chain starting with When(value)
+            if (IsFluentChainStartingWithWhen(invocation, context.SemanticModel, out var chainRoot))
+            {
+                // Check if the chain ends with Set()
+                if (!DoesChainEndWithSet(chainRoot))
+                {
+                    var diagnostic = Diagnostic.Create(Rule, location);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+    }
+
+    private static bool IsFluentChainStartingWithWhen(InvocationExpressionSyntax invocation, SemanticModel semanticModel, out InvocationExpressionSyntax chainRoot)
+    {
+        chainRoot = invocation;
+        
+        // Walk up the chain to find the root invocation
+        var current = invocation;
+        while (current.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            if (memberAccess.Expression is InvocationExpressionSyntax parentInvocation)
+            {
+                current = parentInvocation;
+            }
+            else
+            {
+                break;
+            }
+        }
+        
+        // Check if the root method is named "When"
+        if (current.Expression is MemberAccessExpressionSyntax rootMemberAccess)
+        {
+            return rootMemberAccess.Name.Identifier.Text == "When";
+        }
+        else if (current.Expression is IdentifierNameSyntax identifierName)
+        {
+            return identifierName.Identifier.Text == "When";
+        }
+
+        // Check if this is a direct call to When
+        var symbolInfo = semanticModel.GetSymbolInfo(current);
+        if (symbolInfo.Symbol is IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.Name == "When")
+            {
+                // Verify it returns IFluentSetter<T> or IValidationFluentSetter<T>
+                var returnType = methodSymbol.ReturnType;
+                if (returnType is INamedTypeSymbol namedType)
+                {
+                    var typeName = namedType.Name;
+                    if (typeName == "IFluentSetter" || typeName == "IValidationFluentSetter")
+                    {
+                        chainRoot = current;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool DoesChainEndWithSet(InvocationExpressionSyntax chainRoot)
+    {
+        // Find the last method call in the chain
+        var current = chainRoot;
+        InvocationExpressionSyntax? lastInvocation = null;
+
+        // Traverse to find the outermost invocation (the end of the chain)
+        var node = chainRoot.Parent;
+        while (node != null)
+        {
+            if (node is MemberAccessExpressionSyntax memberAccess && 
+                memberAccess.Expression == (lastInvocation ?? (ExpressionSyntax)current))
+            {
+                if (memberAccess.Parent is InvocationExpressionSyntax parentInvocation)
+                {
+                    lastInvocation = parentInvocation;
+                    node = parentInvocation.Parent;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        // If we found invocations in the chain, check the last one
+        var finalInvocation = lastInvocation ?? current;
+        
+        if (finalInvocation.Expression is MemberAccessExpressionSyntax finalMemberAccess)
+        {
+            return finalMemberAccess.Name.Identifier.Text == "Set";
+        }
+
+        return false;
+    }
+}

--- a/src/MVVMFluent.Analyzers/FluentSetterMustEndWithSetCodeFixProvider.cs
+++ b/src/MVVMFluent.Analyzers/FluentSetterMustEndWithSetCodeFixProvider.cs
@@ -1,0 +1,111 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MVVMFluent.Analyzers;
+
+/// <summary>
+/// Code fix provider that adds .Set() to the end of fluent setter chains.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FluentSetterMustEndWithSetCodeFixProvider)), Shared]
+public class FluentSetterMustEndWithSetCodeFixProvider : CodeFixProvider
+{
+    private const string Title = "Add .Set() to complete fluent setter";
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(FluentSetterMustEndWithSetAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the node at the diagnostic location
+        var node = root.FindToken(diagnosticSpan.Start).Parent;
+        if (node == null)
+        {
+            return;
+        }
+
+        // Find the setter accessor or expression
+        var setterNode = node.AncestorsAndSelf()
+            .FirstOrDefault(n => n is AccessorDeclarationSyntax or ExpressionStatementSyntax);
+
+        if (setterNode == null)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Title,
+                createChangedDocument: c => AddSetCallAsync(context.Document, setterNode, c),
+                equivalenceKey: Title),
+            diagnostic);
+    }
+
+    private static async Task<Document> AddSetCallAsync(Document document, SyntaxNode setterNode, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null)
+        {
+            return document;
+        }
+
+        SyntaxNode newNode;
+
+        if (setterNode is AccessorDeclarationSyntax accessor && accessor.ExpressionBody != null)
+        {
+            // Handle expression-bodied setter: set => When(value).Validate()
+            var originalExpression = accessor.ExpressionBody.Expression;
+            var newExpression = CreateSetCall(originalExpression);
+            var newExpressionBody = accessor.ExpressionBody.WithExpression(newExpression);
+            newNode = accessor.WithExpressionBody(newExpressionBody);
+        }
+        else if (setterNode is ExpressionStatementSyntax expressionStatement)
+        {
+            // Handle statement in block body
+            var originalExpression = expressionStatement.Expression;
+            var newExpression = CreateSetCall(originalExpression);
+            newNode = expressionStatement.WithExpression(newExpression);
+        }
+        else
+        {
+            return document;
+        }
+
+        var newRoot = root.ReplaceNode(setterNode, newNode);
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static ExpressionSyntax CreateSetCall(ExpressionSyntax originalExpression)
+    {
+        // Create: originalExpression.Set()
+        var setIdentifier = SyntaxFactory.IdentifierName("Set");
+        var memberAccess = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            originalExpression,
+            setIdentifier);
+        
+        var invocation = SyntaxFactory.InvocationExpression(memberAccess)
+            .WithArgumentList(SyntaxFactory.ArgumentList());
+
+        return invocation;
+    }
+}

--- a/src/MVVMFluent.Analyzers/MVVMFluent.Analyzers.csproj
+++ b/src/MVVMFluent.Analyzers/MVVMFluent.Analyzers.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageId>MVVMFluent.Analyzers</PackageId>
+    <Authors>Kristoffer Tungland</Authors>
+    <Company>MVVMFluent</Company>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/kristoffer-tungland/MVVMFluent</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/kristoffer-tungland/MVVMFluent</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>MVVM;WPF;Fluent;Analyzer;Roslyn</PackageTags>
+    <Description>Roslyn analyzer for MVVMFluent that enforces proper usage of fluent property setters.</Description>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/MVVMFluent.Analyzers/README.md
+++ b/src/MVVMFluent.Analyzers/README.md
@@ -1,0 +1,136 @@
+# MVVMFluent.Analyzers
+
+A Roslyn analyzer for the MVVMFluent library that enforces proper usage of fluent property setters.
+
+## Rules
+
+### MVVMFLUENT001: Fluent setter must end with Set()
+
+**Severity**: Error
+
+**Description**: Property setters using `When(value)` must end with a call to `Set()` to commit the value to the backing field.
+
+**Why this rule exists**: The fluent setter pattern in MVVMFluent builds up a chain of operations (validation, change notifications, etc.) but doesn't actually store the value until `Set()` is called. Without `Set()`, the value is not committed and property change notifications are not triggered, leading to subtle bugs.
+
+### Example
+
+#### ? Incorrect (will trigger analyzer)
+```csharp
+private string _name;
+public string Name
+{
+    get => _name;
+    set => When(value).Validate(); // Analyzer will report an error: missing Set()!
+}
+
+public string Title
+{
+    get => _title;
+    set => When(value).Validate(); // Analyzer will report an error: missing Set()
+}
+```
+
+#### ? Correct
+```csharp
+private string _name;
+public string Name
+{
+    get => _name;
+    set => When(value).Validate().Set(); // Valid
+}
+```
+
+### Additional Context
+
+This analyzer is important to prevent subtle bugs when working with FluentSetter
+and FluentValidationSetter in the MVVMFluent project.
+
+## Metadata
+
+## Metadata
+
+### Assignees
+
+No one assigned
+
+### Labels
+
+[codex](https://github.com/kristoffer-tungland/MVVMFluent/issues?q=state%3Aopen%20label%3A%22codex%22)
+
+### Projects
+
+No projects
+
+### Milestone
+
+No milestone
+
+### Relationships
+
+None yet
+
+### Development
+
+No branches or pull requests
+
+## Installation
+
+The analyzer is automatically included when you install the MVVMFluent NuGet package. No separate installation is required.
+
+## How It Works
+
+The analyzer examines all property setters in your code and looks for:
+
+1. Calls to the `When(value)` method (from `ViewModelBase` or `ValidationViewModelBase`)
+2. Checks if the method chain ends with a call to `Set()`
+3. Reports an error if `Set()` is missing
+
+The analyzer works with both expression-bodied setters and block-bodied setters:
+
+```csharp
+// Expression-bodied setter
+public string Name
+{
+    get => Get<string>();
+    set => When(value).Set(); // ?
+}
+
+// Block-bodied setter
+public string Title
+{
+    get => Get<string>();
+    set
+    {
+        When(value).Set(); // ?
+    }
+}
+```
+
+## Technical Details
+
+- **Analyzer ID**: MVVMFLUENT001
+- **Category**: Usage
+- **Severity**: Error
+- **Applies to**: Property setters using `When(value)` from MVVMFluent
+
+## Building from Source
+
+```bash
+cd src/MVVMFluent.Analyzers
+dotnet build
+```
+
+## Running Tests
+
+```bash
+cd src/MVVMFluent.Analyzers.Tests
+dotnet test
+```
+
+## Contributing
+
+Contributions are welcome! Please see the main [MVVMFluent repository](https://github.com/kristoffer-tungland/MVVMFluent) for contribution guidelines.
+
+## License
+
+This analyzer is part of the MVVMFluent project and is available under the MIT License.

--- a/src/MVVMFluent/MVVMFluent.csproj
+++ b/src/MVVMFluent/MVVMFluent.csproj
@@ -30,4 +30,9 @@
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="../../LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Include the analyzer in the package -->
+    <ProjectReference Include="..\MVVMFluent.Analyzers\MVVMFluent.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Introduced a new `MVVMFluent.Analyzers` project with a Roslyn analyzer to ensure property setters using `When(value)` end with `.Set()`.

- Added a code fix provider to automatically append `.Set()` when missing.
- Created unit tests for the analyzer and code fix using `Microsoft.CodeAnalysis.Testing`.
- Updated solution structure to include the analyzer and its tests.
- Enhanced documentation to describe the analyzer's purpose, rules, and usage.
- Configured NuGet packaging to include the analyzer in the `MVVMFluent` package.