### PR TITLE
Add XML documentation to public APIs

### DIFF
--- a/src/MVVMFluent/Builders/FluentSetter.cs
+++ b/src/MVVMFluent/Builders/FluentSetter.cs
@@ -5,6 +5,10 @@ using System.Windows.Input;
 
 namespace MVVMFluent.Builders;
 
+/// <summary>
+/// Provides fluent configuration for setting property values and invoking change notifications.
+/// </summary>
+/// <typeparam name="TValue">The type of the property value.</typeparam>
 public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
 {
     private readonly IFluentSetterViewModel _viewModel;
@@ -16,6 +20,12 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
     private IEnumerable<string>? _propertiesToNotify;
     private TValue? _valueToSet;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FluentSetter{TValue}"/> class.
+    /// </summary>
+    /// <param name="viewModel">The owning view model that stores property values.</param>
+    /// <param name="propertyName">The name of the property to update.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="viewModel"/> or <paramref name="propertyName"/> is <see langword="null"/>.</exception>
     public FluentSetter(IFluentSetterViewModel viewModel, string? propertyName)
     {
         if (propertyName == null)
@@ -32,12 +42,19 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         PropertyName = propertyName;
     }
 
+    /// <summary>
+    /// Gets the name of the property that this setter updates.
+    /// </summary>
     public string PropertyName { get; }
 
+    /// <summary>
+    /// Gets the value that will be assigned to the property when <see cref="Set"/> is called.
+    /// </summary>
     protected TValue? ValueToSet => _valueToSet;
 
     internal void SetValue(TValue? value) => _valueToSet = value;
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changing(Action action)
     {
         if (action == null)
@@ -48,6 +65,7 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changing(Action<TValue?> action)
     {
         if (action == null)
@@ -58,6 +76,7 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changing(Action<TValue?, TValue?> action)
     {
         if (action == null)
@@ -68,6 +87,7 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changed(Action action)
     {
         if (action == null)
@@ -78,6 +98,7 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changed(Action<TValue?> action)
     {
         if (action == null)
@@ -88,6 +109,7 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changed(Action<TValue?, TValue?> action)
     {
         if (action == null)
@@ -98,18 +120,21 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Notify(params ICommand[] commands)
     {
         _commandsToReevaluate = commands;
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Notify(params string[] propertyNames)
     {
         _propertiesToNotify = propertyNames;
         return this;
     }
 
+    /// <inheritdoc />
     public virtual void Set()
     {
         var oldValue = _viewModel.GetFieldValue<TValue>(PropertyName);
@@ -168,6 +193,9 @@ public class FluentSetter<TValue> : IFluentSetter<TValue>, IDisposable
         }
     }
 
+    /// <summary>
+    /// Releases the resources used by the fluent setter.
+    /// </summary>
     public virtual void Dispose()
     {
         _onChanging = null;

--- a/src/MVVMFluent/Builders/FluentSetterBuilder.cs
+++ b/src/MVVMFluent/Builders/FluentSetterBuilder.cs
@@ -12,23 +12,43 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
 {
     private readonly FluentSetter<TValue> _fluentSetter;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FluentSetterBuilder{TValue}"/> class.
+    /// </summary>
+    /// <param name="valueToSet">The value to assign to the property.</param>
+    /// <param name="fluentSetterViewModel">The owning view model that manages fluent setters.</param>
+    /// <param name="propertyName">The name of the property to update. Automatically provided by the compiler when omitted.</param>
     public FluentSetterBuilder(TValue? valueToSet, IFluentSetterViewModel fluentSetterViewModel, [CallerMemberName] string? propertyName = null)
         : base(valueToSet, fluentSetterViewModel)
     {
         _fluentSetter = CreateFluentSetter(fluentSetterViewModel, propertyName);
     }
 
+    /// <inheritdoc />
     protected override IFluentSetter<TValue> FluentSetter => _fluentSetter;
 
+    /// <summary>
+    /// Creates the underlying <see cref="FluentSetter{TValue}"/> instance.
+    /// </summary>
+    /// <param name="fluentSetterViewModel">The owning view model.</param>
+    /// <param name="propertyName">The name of the property being configured.</param>
+    /// <returns>A new <see cref="FluentSetter{TValue}"/>.</returns>
     protected virtual FluentSetter<TValue> CreateFluentSetter(IFluentSetterViewModel fluentSetterViewModel, string? propertyName)
     {
         return new FluentSetter<TValue>(fluentSetterViewModel, propertyName);
     }
 
+    /// <summary>
+    /// Gets the underlying <see cref="FluentSetter{TValue}"/> instance used to configure notifications and callbacks.
+    /// </summary>
     protected FluentSetter<TValue> FluentSetterInstance => _fluentSetter;
 
+    /// <summary>
+    /// Gets the name of the property that this builder targets.
+    /// </summary>
     public string PropertyName => FluentSetterInstance.PropertyName;
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changing(Action action)
     {
         if (!IsBuilt)
@@ -39,6 +59,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changing(Action<TValue?> action)
     {
         if (!IsBuilt)
@@ -49,6 +70,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changing(Action<TValue?, TValue?> action)
     {
         if (!IsBuilt)
@@ -59,6 +81,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changed(Action<TValue?> action)
     {
         if (!IsBuilt)
@@ -69,6 +92,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changed(Action action)
     {
         if (!IsBuilt)
@@ -79,6 +103,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Changed(Action<TValue?, TValue?> action)
     {
         if (!IsBuilt)
@@ -89,6 +114,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Notify(params ICommand[] commands)
     {
         if (!IsBuilt)
@@ -99,6 +125,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public IFluentSetter<TValue> Notify(params string[] propertyNames)
     {
         if (!IsBuilt)
@@ -109,6 +136,7 @@ public class FluentSetterBuilder<TValue> : FluentSetterBuilderBase<TValue>, IFlu
         return this;
     }
 
+    /// <inheritdoc />
     public override void Set()
     {
         FluentSetterInstance.SetValue(_valueToSet);

--- a/src/MVVMFluent/Builders/FluentSetterBuilderBase.cs
+++ b/src/MVVMFluent/Builders/FluentSetterBuilderBase.cs
@@ -12,6 +12,12 @@ public abstract class FluentSetterBuilderBase<TValue> : IFluentSetterBuilder, ID
     private readonly IFluentSetterViewModel _viewModel;
     private bool _disposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FluentSetterBuilderBase{TValue}"/> class.
+    /// </summary>
+    /// <param name="valueToSet">The value that should be assigned when the setter executes.</param>
+    /// <param name="fluentSetterViewModel">The owning view model that tracks fluent setters.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fluentSetterViewModel"/> is <see langword="null"/>.</exception>
     protected FluentSetterBuilderBase(TValue? valueToSet, IFluentSetterViewModel fluentSetterViewModel)
     {
         _viewModel = fluentSetterViewModel ?? throw new ArgumentNullException(nameof(fluentSetterViewModel));
@@ -20,16 +26,30 @@ public abstract class FluentSetterBuilderBase<TValue> : IFluentSetterBuilder, ID
 
     protected TValue? _valueToSet;
 
+    /// <summary>
+    /// Gets a value indicating whether the builder has been built and registered with the owning view model.
+    /// </summary>
     public bool IsBuilt { get; private set; }
 
+    /// <summary>
+    /// Gets the fluent setter that performs the actual value assignment.
+    /// </summary>
     protected abstract IFluentSetter<TValue> FluentSetter { get; }
 
+    /// <summary>
+    /// Gets the name of the property targeted by this builder.
+    /// </summary>
+    /// <returns>The property name associated with the underlying fluent setter.</returns>
     public string GetPropertyName() => FluentSetter.PropertyName;
 
     internal void ValueToSet(TValue? value) => _valueToSet = value;
 
     void IFluentSetterBuilder.Build() => Build();
 
+    /// <summary>
+    /// Builds the fluent setter and registers it with the owning view model.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the builder has already been built.</exception>
     internal void Build()
     {
         if (IsBuilt)
@@ -41,6 +61,9 @@ public abstract class FluentSetterBuilderBase<TValue> : IFluentSetterBuilder, ID
         IsBuilt = true;
     }
 
+    /// <summary>
+    /// Applies the configured value to the underlying property.
+    /// </summary>
     public virtual void Set()
     {
         if (!IsBuilt)
@@ -51,12 +74,19 @@ public abstract class FluentSetterBuilderBase<TValue> : IFluentSetterBuilder, ID
         FluentSetter.Set();
     }
 
+    /// <summary>
+    /// Releases the resources used by the builder.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Releases the unmanaged resources used by the builder and optionally disposes of managed resources.
+    /// </summary>
+    /// <param name="disposing">A value indicating whether to dispose managed resources.</param>
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed)
@@ -78,6 +108,9 @@ public abstract class FluentSetterBuilderBase<TValue> : IFluentSetterBuilder, ID
         _disposed = true;
     }
 
+    /// <summary>
+    /// Performs additional cleanup logic when the builder is disposed.
+    /// </summary>
     protected virtual void DisposeInternal()
     {
     }

--- a/src/MVVMFluent/Commands/AsyncFluentCommand.cs
+++ b/src/MVVMFluent/Commands/AsyncFluentCommand.cs
@@ -22,15 +22,27 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
     private bool _isRunning;
     private int _progress;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncFluentCommand"/> class.
+    /// </summary>
     public AsyncFluentCommand()
     {
         PropertyChanged += OnSelfPropertyChanged;
     }
 
+    /// <summary>
+    /// Occurs when changes affecting the ability of the command to execute should be re-evaluated.
+    /// </summary>
     public event EventHandler? CanExecuteChanged;
 
+    /// <summary>
+    /// Occurs when a property value on the command changes.
+    /// </summary>
     public event PropertyChangedEventHandler? PropertyChanged;
 
+    /// <summary>
+    /// Gets a value indicating whether the command is currently running.
+    /// </summary>
     public bool IsRunning
     {
         get => _isRunning;
@@ -47,6 +59,9 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         }
     }
 
+    /// <summary>
+    /// Gets or sets the progress of the command execution as a percentage between 0 and 100.
+    /// </summary>
     public int Progress
     {
         get => _progress;
@@ -62,10 +77,19 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         }
     }
 
+    /// <summary>
+    /// Gets the view model that owns this command, if any.
+    /// </summary>
     public IFluentSetterViewModel? Owner { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the command has been fully configured and built.
+    /// </summary>
     public bool IsBuilt { get; private set; }
 
+    /// <summary>
+    /// Gets a command that can be used to cancel the currently running operation.
+    /// </summary>
     public IFluentCommand CancelCommand
     {
         get
@@ -81,12 +105,26 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         }
     }
 
+    /// <summary>
+    /// Gets the <see cref="CancellationTokenSource"/> that controls cancellation for the current execution, or <see langword="null"/> if the command is idle.
+    /// </summary>
     public CancellationTokenSource? CancellationTokenSource => _cts;
 
+    /// <summary>
+    /// Gets a value indicating whether cancellation has been requested for the current execution.
+    /// </summary>
     public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
 
+    /// <summary>
+    /// Marks the command as built, preventing further configuration changes.
+    /// </summary>
     public void MarkAsBuilt() => IsBuilt = true;
 
+    /// <summary>
+    /// Sets the delegate that will be executed when the command runs.
+    /// </summary>
+    /// <param name="execute">The delegate to execute. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     protected void SetExecute(Func<object?, CancellationToken, Task> execute)
     {
         if (execute == null)
@@ -96,6 +134,13 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         _execute = execute;
     }
 
+    /// <summary>
+    /// Creates a new asynchronous command that executes the specified delegate without a parameter or cancellation token.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="AsyncFluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static AsyncFluentCommand Do(Func<Task> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -108,6 +153,13 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return command;
     }
 
+    /// <summary>
+    /// Creates a new asynchronous command that executes the specified delegate with a parameter but without a cancellation token.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="AsyncFluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static AsyncFluentCommand Do(Func<object?, Task> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -120,6 +172,13 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return command;
     }
 
+    /// <summary>
+    /// Creates a new asynchronous command that executes the specified delegate with a parameter and cancellation token.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="AsyncFluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static AsyncFluentCommand Do(Func<object?, CancellationToken, Task> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -132,8 +191,19 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return command;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/>.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand"/> instance.</returns>
     public AsyncFluentCommand If(Func<bool> canExecute) => If(_ => canExecute());
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/> for the given parameter.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="canExecute"/> is <see langword="null"/>.</exception>
     public AsyncFluentCommand If(Func<object?, bool> canExecute)
     {
         if (IsBuilt)
@@ -149,6 +219,11 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return this;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the specified properties are free of validation errors.
+    /// </summary>
+    /// <param name="propertyNames">The property names that must be valid before the command can execute.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand"/> instance.</returns>
     public AsyncFluentCommand IfValid(params string[] propertyNames)
     {
         EnsurePropertyNames(propertyNames);
@@ -161,6 +236,12 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return If(() => HasNoErrors(propertyNames));
     }
 
+    /// <summary>
+    /// Registers an exception handler that is invoked when the asynchronous execution fails.
+    /// </summary>
+    /// <param name="handle">The exception handler to invoke.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="handle"/> is <see langword="null"/>.</exception>
     public AsyncFluentCommand Handle(Action<Exception> handle)
     {
         if (IsBuilt)
@@ -176,6 +257,11 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return this;
     }
 
+    /// <summary>
+    /// Configures whether continuations should capture the current synchronization context.
+    /// </summary>
+    /// <param name="continueOnCapturedContext">A value indicating whether to resume on the captured context.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand"/> instance.</returns>
     public AsyncFluentCommand ConfigureAwait(bool continueOnCapturedContext)
     {
         if (IsBuilt)
@@ -187,9 +273,20 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         return this;
     }
 
+    /// <summary>
+    /// Determines whether the command can execute using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to evaluate.</param>
+    /// <returns><see langword="true"/> if the command can execute; otherwise, <see langword="false"/>.</returns>
     public bool CanExecute(object? parameter)
         => !IsRunning && (_canExecute?.Invoke(parameter) ?? true);
 
+    /// <summary>
+    /// Executes the command asynchronously using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to pass to the execution delegate.</param>
+    /// <returns>A task that represents the asynchronous execution.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no execution delegate has been configured.</exception>
     public async Task ExecuteAsync(object? parameter)
     {
         if (_execute == null)
@@ -220,11 +317,18 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         }
     }
 
+    /// <summary>
+    /// Executes the command asynchronously and observes exceptions using the configured handler.
+    /// </summary>
+    /// <param name="parameter">The parameter to pass to the execution delegate.</param>
     public void Execute(object? parameter)
     {
         ExecuteAsync(parameter).RunWithExceptionHandling(ex => _onException?.Invoke(ex), _continueOnCapturedContext);
     }
 
+    /// <summary>
+    /// Requests cancellation of the current operation, if one is running.
+    /// </summary>
     public void Cancel()
     {
         if (IsRunning && _cts is { IsCancellationRequested: false })
@@ -233,11 +337,20 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         }
     }
 
+    /// <summary>
+    /// Reports progress by setting the <see cref="Progress"/> property directly.
+    /// </summary>
+    /// <param name="progress">The progress percentage between 0 and 100.</param>
     public void ReportProgress(int progress)
     {
         Progress = progress;
     }
 
+    /// <summary>
+    /// Reports progress by calculating the completion percentage from the supplied values.
+    /// </summary>
+    /// <param name="current">The current progress value.</param>
+    /// <param name="total">The total progress value.</param>
     public void ReportProgress(int current, int total)
     {
         if (total <= 0)
@@ -250,8 +363,16 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         ReportProgress((int)(ratio * 100));
     }
 
+    /// <summary>
+    /// Raises the <see cref="CanExecuteChanged"/> event to notify listeners that the command's execution state may have changed.
+    /// </summary>
     public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 
+    /// <summary>
+    /// Raises the <see cref="PropertyChanged"/> event for the specified property.
+    /// </summary>
+    /// <param name="propertyName">The name of the property that changed.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="propertyName"/> is <see langword="null"/>.</exception>
     protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         if (propertyName == null)
@@ -308,12 +429,19 @@ public class AsyncFluentCommand : IAsyncFluentCommand, INotifyPropertyChanged, I
         }
     }
 
+    /// <summary>
+    /// Releases the resources used by the command.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Releases the unmanaged resources used by the command and optionally disposes of managed resources.
+    /// </summary>
+    /// <param name="disposing">A value indicating whether to dispose managed resources.</param>
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed)
@@ -353,15 +481,27 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
     private bool _isRunning;
     private int _progress;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncFluentCommand{T}"/> class.
+    /// </summary>
     public AsyncFluentCommand()
     {
         PropertyChanged += OnSelfPropertyChanged;
     }
 
+    /// <summary>
+    /// Occurs when changes affecting the ability of the command to execute should be re-evaluated.
+    /// </summary>
     public event EventHandler? CanExecuteChanged;
 
+    /// <summary>
+    /// Occurs when a property value on the command changes.
+    /// </summary>
     public event PropertyChangedEventHandler? PropertyChanged;
 
+    /// <summary>
+    /// Gets a value indicating whether the command is currently running.
+    /// </summary>
     public bool IsRunning
     {
         get => _isRunning;
@@ -378,6 +518,9 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
     }
 
+    /// <summary>
+    /// Gets or sets the progress of the command execution as a percentage between 0 and 100.
+    /// </summary>
     public int Progress
     {
         get => _progress;
@@ -393,10 +536,19 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
     }
 
+    /// <summary>
+    /// Gets the view model that owns this command, if any.
+    /// </summary>
     public IFluentSetterViewModel? Owner { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the command has been fully configured and built.
+    /// </summary>
     public bool IsBuilt { get; private set; }
 
+    /// <summary>
+    /// Gets a command that can be used to cancel the currently running operation.
+    /// </summary>
     public IFluentCommand CancelCommand
     {
         get
@@ -412,12 +564,26 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
     }
 
+    /// <summary>
+    /// Gets the <see cref="CancellationTokenSource"/> that controls cancellation for the current execution, or <see langword="null"/> if the command is idle.
+    /// </summary>
     public CancellationTokenSource? CancellationTokenSource => _cts;
 
+    /// <summary>
+    /// Gets a value indicating whether cancellation has been requested for the current execution.
+    /// </summary>
     public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
 
+    /// <summary>
+    /// Marks the command as built, preventing further configuration changes.
+    /// </summary>
     public void MarkAsBuilt() => IsBuilt = true;
 
+    /// <summary>
+    /// Sets the delegate that will be executed when the command runs.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     protected void SetExecute(Func<T?, CancellationToken, Task> execute)
     {
         if (execute == null)
@@ -427,6 +593,13 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         _execute = execute;
     }
 
+    /// <summary>
+    /// Creates a new asynchronous command that executes the specified delegate.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="AsyncFluentCommand{T}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static AsyncFluentCommand<T> Do(Func<T?, Task> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -435,10 +608,17 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
 
         var command = new AsyncFluentCommand<T> { Owner = owner };
-        command.SetExecute((value, _) => execute(value));
+        command.SetExecute((o, _) => execute(o));
         return command;
     }
 
+    /// <summary>
+    /// Creates a new asynchronous command that executes the specified delegate with cancellation support.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="AsyncFluentCommand{T}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static AsyncFluentCommand<T> Do(Func<T?, CancellationToken, Task> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -451,8 +631,19 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         return command;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/>.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand{T}"/> instance.</returns>
     public AsyncFluentCommand<T> If(Func<bool> canExecute) => If(_ => canExecute());
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/> for the given parameter.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand{T}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="canExecute"/> is <see langword="null"/>.</exception>
     public AsyncFluentCommand<T> If(Func<T?, bool> canExecute)
     {
         if (IsBuilt)
@@ -468,6 +659,11 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         return this;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the specified properties are free of validation errors.
+    /// </summary>
+    /// <param name="propertyNames">The property names that must be valid before the command can execute.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand{T}"/> instance.</returns>
     public AsyncFluentCommand<T> IfValid(params string[] propertyNames)
     {
         EnsurePropertyNames(propertyNames);
@@ -480,6 +676,12 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         return If(() => HasNoErrors(propertyNames));
     }
 
+    /// <summary>
+    /// Registers an exception handler that is invoked when the asynchronous execution fails.
+    /// </summary>
+    /// <param name="handle">The exception handler to invoke.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand{T}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="handle"/> is <see langword="null"/>.</exception>
     public AsyncFluentCommand<T> Handle(Action<Exception> handle)
     {
         if (IsBuilt)
@@ -495,6 +697,11 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         return this;
     }
 
+    /// <summary>
+    /// Configures whether continuations should capture the current synchronization context.
+    /// </summary>
+    /// <param name="continueOnCapturedContext">A value indicating whether to resume on the captured context.</param>
+    /// <returns>The current <see cref="AsyncFluentCommand{T}"/> instance.</returns>
     public AsyncFluentCommand<T> ConfigureAwait(bool continueOnCapturedContext)
     {
         if (IsBuilt)
@@ -506,17 +713,33 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         return this;
     }
 
+    /// <summary>
+    /// Determines whether the command can execute using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to evaluate.</param>
+    /// <returns><see langword="true"/> if the command can execute; otherwise, <see langword="false"/>.</returns>
     public bool CanExecute(object? parameter)
     {
         var typedParameter = parameter is T value ? value : default;
         return !IsRunning && (_canExecute?.Invoke(typedParameter) ?? true);
     }
 
+    /// <summary>
+    /// Executes the command asynchronously using the supplied parameter, converting it to the expected type when possible.
+    /// </summary>
+    /// <param name="parameter">The parameter to pass to the execution delegate.</param>
+    /// <returns>A task that represents the asynchronous execution.</returns>
     public Task ExecuteAsync(object? parameter)
     {
         return ExecuteAsync(parameter is T value ? value : default);
     }
 
+    /// <summary>
+    /// Executes the command asynchronously using the supplied strongly-typed parameter.
+    /// </summary>
+    /// <param name="parameter">The strongly-typed parameter to pass to the execution delegate.</param>
+    /// <returns>A task that represents the asynchronous execution.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no execution delegate has been configured.</exception>
     public async Task ExecuteAsync(T? parameter)
     {
         if (_execute == null)
@@ -547,11 +770,18 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
     }
 
+    /// <summary>
+    /// Executes the command asynchronously and observes exceptions using the configured handler.
+    /// </summary>
+    /// <param name="parameter">The parameter to pass to the execution delegate.</param>
     public void Execute(object? parameter)
     {
         ExecuteAsync(parameter).RunWithExceptionHandling(ex => _onException?.Invoke(ex), _continueOnCapturedContext);
     }
 
+    /// <summary>
+    /// Requests cancellation of the current operation, if one is running.
+    /// </summary>
     public void Cancel()
     {
         if (IsRunning && _cts is { IsCancellationRequested: false })
@@ -560,11 +790,20 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
     }
 
+    /// <summary>
+    /// Reports progress by setting the <see cref="Progress"/> property directly.
+    /// </summary>
+    /// <param name="progress">The progress percentage between 0 and 100.</param>
     public void ReportProgress(int progress)
     {
         Progress = progress;
     }
 
+    /// <summary>
+    /// Reports progress by calculating the completion percentage from the supplied values.
+    /// </summary>
+    /// <param name="current">The current progress value.</param>
+    /// <param name="total">The total progress value.</param>
     public void ReportProgress(int current, int total)
     {
         if (total <= 0)
@@ -577,8 +816,16 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         ReportProgress((int)(ratio * 100));
     }
 
+    /// <summary>
+    /// Raises the <see cref="CanExecuteChanged"/> event to notify listeners that the command's execution state may have changed.
+    /// </summary>
     public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 
+    /// <summary>
+    /// Raises the <see cref="PropertyChanged"/> event for the specified property.
+    /// </summary>
+    /// <param name="propertyName">The name of the property that changed.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="propertyName"/> is <see langword="null"/>.</exception>
     protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         if (propertyName == null)
@@ -635,12 +882,19 @@ public class AsyncFluentCommand<T> : IAsyncFluentCommand<T>, INotifyPropertyChan
         }
     }
 
+    /// <summary>
+    /// Releases the resources used by the command.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Releases the unmanaged resources used by the command and optionally disposes of managed resources.
+    /// </summary>
+    /// <param name="disposing">A value indicating whether to dispose managed resources.</param>
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed)

--- a/src/MVVMFluent/Commands/FluentCommand.cs
+++ b/src/MVVMFluent/Commands/FluentCommand.cs
@@ -12,14 +12,31 @@ public class FluentCommand : IFluentCommand
     private Func<object?, bool>? _canExecute;
     private bool _disposed;
 
+    /// <summary>
+    /// Gets a value indicating whether the command has been fully configured and built.
+    /// </summary>
     public bool IsBuilt { get; private set; }
 
+    /// <summary>
+    /// Gets the view model that owns this command, if any.
+    /// </summary>
     public IFluentSetterViewModel? Owner { get; private set; }
 
+    /// <summary>
+    /// Occurs when changes affecting the ability of the command to execute should be re-evaluated.
+    /// </summary>
     public event EventHandler? CanExecuteChanged;
 
+    /// <summary>
+    /// Marks the command as built, preventing further configuration changes.
+    /// </summary>
     public void MarkAsBuilt() => IsBuilt = true;
 
+    /// <summary>
+    /// Sets the delegate that will be executed when the command runs.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     protected void SetCommand(Action<object?> execute)
     {
         if (execute == null)
@@ -29,6 +46,13 @@ public class FluentCommand : IFluentCommand
         _execute = execute;
     }
 
+    /// <summary>
+    /// Creates a new command that executes the specified delegate without a parameter.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="FluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static FluentCommand Do(Action execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -41,6 +65,13 @@ public class FluentCommand : IFluentCommand
         return command;
     }
 
+    /// <summary>
+    /// Creates a new command that executes the specified delegate with a parameter.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="FluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static FluentCommand Do(Action<object?> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -53,8 +84,19 @@ public class FluentCommand : IFluentCommand
         return command;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/>.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="FluentCommand"/> instance.</returns>
     public FluentCommand If(Func<bool> canExecute) => If(_ => canExecute());
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/> for the given parameter.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="FluentCommand"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="canExecute"/> is <see langword="null"/>.</exception>
     public FluentCommand If(Func<object?, bool> canExecute)
     {
         if (IsBuilt)
@@ -70,6 +112,11 @@ public class FluentCommand : IFluentCommand
         return this;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the specified properties are free of validation errors.
+    /// </summary>
+    /// <param name="propertyNames">The property names that must be valid before the command can execute.</param>
+    /// <returns>The current <see cref="FluentCommand"/> instance.</returns>
     public FluentCommand IfValid(params string[] propertyNames)
     {
         EnsurePropertyNames(propertyNames);
@@ -82,8 +129,19 @@ public class FluentCommand : IFluentCommand
         return If(() => HasNoErrors(propertyNames));
     }
 
+    /// <summary>
+    /// Determines whether the command can execute using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to evaluate.</param>
+    /// <returns><see langword="true"/> if the command can execute; otherwise, <see langword="false"/>.</returns>
     public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
 
+    /// <summary>
+    /// Executes the command using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to pass to the execution delegate.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the command has already been disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no execution delegate has been configured.</exception>
     public void Execute(object? parameter)
     {
         if (_disposed)
@@ -102,6 +160,9 @@ public class FluentCommand : IFluentCommand
         }
     }
 
+    /// <summary>
+    /// Raises the <see cref="CanExecuteChanged"/> event to notify listeners that the command's execution state may have changed.
+    /// </summary>
     public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 
     private bool HasNoErrors(string[] propertyNames)
@@ -145,6 +206,9 @@ public class FluentCommand : IFluentCommand
         }
     }
 
+    /// <summary>
+    /// Releases the resources used by the command.
+    /// </summary>
     public virtual void Dispose()
     {
         if (_disposed)
@@ -170,14 +234,31 @@ public class FluentCommand<T> : IFluentCommand<T>
     private Func<T?, bool>? _canExecute;
     private bool _disposed;
 
+    /// <summary>
+    /// Gets a value indicating whether the command has been fully configured and built.
+    /// </summary>
     public bool IsBuilt { get; private set; }
 
+    /// <summary>
+    /// Gets the view model that owns this command, if any.
+    /// </summary>
     public IFluentSetterViewModel? Owner { get; private set; }
 
+    /// <summary>
+    /// Occurs when changes affecting the ability of the command to execute should be re-evaluated.
+    /// </summary>
     public event EventHandler? CanExecuteChanged;
 
+    /// <summary>
+    /// Marks the command as built, preventing further configuration changes.
+    /// </summary>
     public void MarkAsBuilt() => IsBuilt = true;
 
+    /// <summary>
+    /// Sets the delegate that will be executed when the command runs.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     protected void SetCommand(Action<T?> execute)
     {
         if (execute == null)
@@ -187,6 +268,13 @@ public class FluentCommand<T> : IFluentCommand<T>
         _execute = execute;
     }
 
+    /// <summary>
+    /// Creates a new command that executes the specified delegate with a strongly-typed parameter.
+    /// </summary>
+    /// <param name="execute">The delegate to execute.</param>
+    /// <param name="owner">The owning view model, if any.</param>
+    /// <returns>A configured <see cref="FluentCommand{T}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="execute"/> is <see langword="null"/>.</exception>
     public static FluentCommand<T> Do(Action<T?> execute, IFluentSetterViewModel? owner)
     {
         if (execute == null)
@@ -199,8 +287,19 @@ public class FluentCommand<T> : IFluentCommand<T>
         return command;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/>.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="FluentCommand{T}"/> instance.</returns>
     public FluentCommand<T> If(Func<bool> canExecute) => If(_ => canExecute());
 
+    /// <summary>
+    /// Configures the command to only execute when the supplied predicate evaluates to <see langword="true"/> for the given parameter.
+    /// </summary>
+    /// <param name="canExecute">The predicate that determines whether the command can execute.</param>
+    /// <returns>The current <see cref="FluentCommand{T}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="canExecute"/> is <see langword="null"/>.</exception>
     public FluentCommand<T> If(Func<T?, bool> canExecute)
     {
         if (IsBuilt)
@@ -216,6 +315,11 @@ public class FluentCommand<T> : IFluentCommand<T>
         return this;
     }
 
+    /// <summary>
+    /// Configures the command to only execute when the specified properties are free of validation errors.
+    /// </summary>
+    /// <param name="propertyNames">The property names that must be valid before the command can execute.</param>
+    /// <returns>The current <see cref="FluentCommand{T}"/> instance.</returns>
     public FluentCommand<T> IfValid(params string[] propertyNames)
     {
         EnsurePropertyNames(propertyNames);
@@ -228,11 +332,21 @@ public class FluentCommand<T> : IFluentCommand<T>
         return If(() => HasNoErrors(propertyNames));
     }
 
+    /// <summary>
+    /// Determines whether the command can execute using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to evaluate.</param>
+    /// <returns><see langword="true"/> if the command can execute; otherwise, <see langword="false"/>.</returns>
     public bool CanExecute(object? parameter)
     {
         return _canExecute?.Invoke(parameter is T typed ? typed : default) ?? true;
     }
 
+    /// <summary>
+    /// Executes the command using the supplied parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter to pass to the execution delegate.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when the command has already been disposed.</exception>
     public void Execute(object? parameter)
     {
         if (_disposed)
@@ -248,6 +362,9 @@ public class FluentCommand<T> : IFluentCommand<T>
         _execute?.Invoke(parameter is T typed ? typed : default);
     }
 
+    /// <summary>
+    /// Raises the <see cref="CanExecuteChanged"/> event to notify listeners that the command's execution state may have changed.
+    /// </summary>
     public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 
     private bool HasNoErrors(string[] propertyNames)
@@ -291,6 +408,9 @@ public class FluentCommand<T> : IFluentCommand<T>
         }
     }
 
+    /// <summary>
+    /// Releases the resources used by the command.
+    /// </summary>
     public virtual void Dispose()
     {
         if (_disposed)

--- a/src/MVVMFluent/Extensions/TaskExtensions.cs
+++ b/src/MVVMFluent/Extensions/TaskExtensions.cs
@@ -3,8 +3,18 @@ using System.Threading.Tasks;
 
 namespace MVVMFluent;
 
+/// <summary>
+/// Provides helper extension methods for working with <see cref="Task"/> instances in view models.
+/// </summary>
 public static class TaskExtensions
 {
+    /// <summary>
+    /// Executes the specified task and forwards any thrown exception to the provided handler.
+    /// </summary>
+    /// <param name="task">The task to execute.</param>
+    /// <param name="handle">The handler that receives any exception thrown by the task.</param>
+    /// <param name="continueOnCapturedContext">A value indicating whether to resume on the captured synchronization context.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="task"/> or <paramref name="handle"/> is <see langword="null"/>.</exception>
     public static async void RunWithExceptionHandling(this Task task, Action<Exception> handle, bool continueOnCapturedContext)
     {
         if (task == null)

--- a/src/MVVMFluent/Interfaces/IFluentSetterBuilder.cs
+++ b/src/MVVMFluent/Interfaces/IFluentSetterBuilder.cs
@@ -1,10 +1,23 @@
 namespace MVVMFluent.Interfaces;
 
+/// <summary>
+/// Represents a builder that creates and configures a fluent setter instance.
+/// </summary>
 public interface IFluentSetterBuilder
 {
+    /// <summary>
+    /// Gets a value indicating whether the builder has been executed and the setter registered.
+    /// </summary>
     bool IsBuilt { get; }
 
+    /// <summary>
+    /// Completes the builder configuration and registers it with the owning view model.
+    /// </summary>
     void Build();
 
+    /// <summary>
+    /// Gets the name of the property associated with the fluent setter produced by this builder.
+    /// </summary>
+    /// <returns>The property name targeted by the builder.</returns>
     string GetPropertyName();
 }

--- a/src/MVVMFluent/Interfaces/IFluentSetterViewModel.cs
+++ b/src/MVVMFluent/Interfaces/IFluentSetterViewModel.cs
@@ -1,14 +1,42 @@
 namespace MVVMFluent.Interfaces;
 
+/// <summary>
+/// Defines the contract required by view models that support fluent property setters.
+/// </summary>
 public interface IFluentSetterViewModel
 {
+    /// <summary>
+    /// Registers a fluent setter builder with the view model.
+    /// </summary>
+    /// <param name="fluentSetterBuilder">The builder to register.</param>
     void AddFluentSetterBuilder(IFluentSetterBuilder fluentSetterBuilder);
 
+    /// <summary>
+    /// Retrieves a fluent setter builder for the specified property if one exists.
+    /// </summary>
+    /// <param name="propertyName">The name of the property.</param>
+    /// <returns>The fluent setter builder for the property, or <see langword="null"/> if none is registered.</returns>
     IFluentSetterBuilder? GetFluentSetterBuilder(string propertyName);
 
+    /// <summary>
+    /// Gets the current backing-field value for the specified property.
+    /// </summary>
+    /// <typeparam name="T">The type of the property value.</typeparam>
+    /// <param name="propertyName">The name of the property.</param>
+    /// <returns>The stored value for the property.</returns>
     T? GetFieldValue<T>(string propertyName);
 
+    /// <summary>
+    /// Sets the backing-field value for the specified property.
+    /// </summary>
+    /// <typeparam name="T">The type of the property value.</typeparam>
+    /// <param name="propertyName">The name of the property.</param>
+    /// <param name="value">The value to store.</param>
     void SetFieldValue<T>(string propertyName, T? value);
 
+    /// <summary>
+    /// Raises a <c>PropertyChanged</c> notification for the specified property name.
+    /// </summary>
+    /// <param name="propertyName">The name of the property that changed.</param>
     void OnPropertyChanged(string? propertyName);
 }

--- a/src/MVVMFluent/Interfaces/IValidationFluentSetterBuilder.cs
+++ b/src/MVVMFluent/Interfaces/IValidationFluentSetterBuilder.cs
@@ -2,11 +2,25 @@ using System.Collections;
 
 namespace MVVMFluent.Interfaces;
 
+/// <summary>
+/// Represents a fluent setter builder that supports validation of property values.
+/// </summary>
 public interface IValidationFluentSetterBuilder : IFluentSetterBuilder
 {
+    /// <summary>
+    /// Gets a value indicating whether the builder currently has validation errors.
+    /// </summary>
     bool HasErrors { get; }
 
+    /// <summary>
+    /// Evaluates the configured validation rules against the provided value.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
     void CheckForErrors(object? value);
 
+    /// <summary>
+    /// Gets the collection of validation errors produced by the builder.
+    /// </summary>
+    /// <returns>An enumerable collection of error messages.</returns>
     IEnumerable GetErrors();
 }

--- a/src/MVVMFluent/Interfaces/IValidationFluentSetterViewModel.cs
+++ b/src/MVVMFluent/Interfaces/IValidationFluentSetterViewModel.cs
@@ -2,8 +2,20 @@ using System.ComponentModel;
 
 namespace MVVMFluent.Interfaces;
 
+/// <summary>
+/// Represents a view model that supports fluent setters with validation capabilities.
+/// </summary>
 public interface IValidationFluentSetterViewModel : IFluentSetterViewModel, INotifyDataErrorInfo
 {
+    /// <summary>
+    /// Triggers validation for the specified property using its current value.
+    /// </summary>
+    /// <param name="propertyName">The name of the property to validate.</param>
     void CheckErrorsFor(string? propertyName);
+
+    /// <summary>
+    /// Raises a <see cref="INotifyDataErrorInfo.ErrorsChanged"/> event for the specified property name.
+    /// </summary>
+    /// <param name="propertyName">The name of the property whose errors changed.</param>
     void RaiseErrorsChanged(string? propertyName);
 }

--- a/src/MVVMFluent/Validation/RequiredValidationRule.cs
+++ b/src/MVVMFluent/Validation/RequiredValidationRule.cs
@@ -3,15 +3,23 @@ using System.Globalization;
 
 namespace MVVMFluent.Validation;
 
+/// <summary>
+/// Represents a validation rule that ensures a value is not null or whitespace.
+/// </summary>
 public class RequiredValidationRule : ValidationRule
 {
     private readonly string? _errorMessage;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiredValidationRule"/> class.
+    /// </summary>
+    /// <param name="errorMessage">An optional custom error message to use when validation fails.</param>
     public RequiredValidationRule(string? errorMessage = null)
     {
         _errorMessage = errorMessage;
     }
 
+    /// <inheritdoc />
     public override ValidationResult? Validate(object? value, CultureInfo cultureInfo)
     {
         if (value == null)

--- a/src/MVVMFluent/Validation/ValidationFluentSetter.cs
+++ b/src/MVVMFluent/Validation/ValidationFluentSetter.cs
@@ -9,6 +9,10 @@ using System.Globalization;
 
 namespace MVVMFluent.Validation;
 
+/// <summary>
+/// Extends <see cref="FluentSetter{TValue}"/> with validation rule composition for property values.
+/// </summary>
+/// <typeparam name="TValue">The type of the property value.</typeparam>
 public class ValidationFluentSetter<TValue> : FluentSetter<TValue>, IValidationFluentSetter<TValue>
 {
     private readonly List<IValidationRule> _rules = new();
@@ -16,18 +20,31 @@ public class ValidationFluentSetter<TValue> : FluentSetter<TValue>, IValidationF
     private Func<TValue?, bool>? _validationFunction;
     private string? _errorMessage;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationFluentSetter{TValue}"/> class.
+    /// </summary>
+    /// <param name="viewModel">The owning view model that supports validation.</param>
+    /// <param name="propertyName">The name of the property to update.</param>
     public ValidationFluentSetter(IValidationFluentSetterViewModel viewModel, string? propertyName)
         : base(viewModel, propertyName)
     {
         _viewModel = viewModel;
     }
 
+    /// <summary>
+    /// Gets the collection of validation error messages for the property.
+    /// </summary>
     public ObservableCollection<string> Errors { get; } = new();
 
+    /// <summary>
+    /// Gets a value indicating whether validation errors are present.
+    /// </summary>
     public bool HasErrors { get; private set; }
 
+    /// <inheritdoc />
     public IEnumerable GetErrors() => Errors;
 
+    /// <inheritdoc />
     public IValidationFluentSetter<TValue> Validate(params IValidationRule[] rules)
     {
         if (rules == null)
@@ -43,6 +60,7 @@ public class ValidationFluentSetter<TValue> : FluentSetter<TValue>, IValidationF
         return this;
     }
 
+    /// <inheritdoc />
     public IValidationFluentSetter<TValue> Validate(Func<TValue?, bool> validationFunction, string? errorMessage)
     {
         if (validationFunction == null)
@@ -55,11 +73,17 @@ public class ValidationFluentSetter<TValue> : FluentSetter<TValue>, IValidationF
         return this;
     }
 
+    /// <inheritdoc />
     public IValidationFluentSetter<TValue> HasValue(string? errorMessage = null)
     {
         return Validate(new RequiredValidationRule(errorMessage));
     }
 
+    /// <summary>
+    /// Adds a validation rule to the current builder.
+    /// </summary>
+    /// <param name="rule">The validation rule to add.</param>
+    /// <returns>The current <see cref="ValidationFluentSetter{TValue}"/> instance.</returns>
     internal ValidationFluentSetter<TValue> AddRule(IValidationRule rule)
     {
         if (rule == null)
@@ -75,17 +99,23 @@ public class ValidationFluentSetter<TValue> : FluentSetter<TValue>, IValidationF
         return this;
     }
 
+    /// <inheritdoc />
     public override void Set()
     {
         CheckForErrors(ValueToSet);
         base.Set();
     }
 
+    /// <summary>
+    /// Executes validation for the specified value.
+    /// </summary>
+    /// <param name="valueToSet">The value to validate.</param>
     public void CheckForErrors(TValue? valueToSet)
     {
         CheckForErrors((object?)valueToSet);
     }
 
+    /// <inheritdoc />
     public void CheckForErrors(object? valueToSet)
     {
         Errors.Clear();

--- a/src/MVVMFluent/Validation/ValidationFluentSetterBuilder.cs
+++ b/src/MVVMFluent/Validation/ValidationFluentSetterBuilder.cs
@@ -6,13 +6,24 @@ using System.Runtime.CompilerServices;
 
 namespace MVVMFluent.Validation;
 
+/// <summary>
+/// Provides a fluent setter builder that also composes validation rules for the target property.
+/// </summary>
+/// <typeparam name="TValue">The type of the property value.</typeparam>
 public class ValidationFluentSetterBuilder<TValue> : FluentSetterBuilder<TValue>, IValidationFluentSetterBuilder, IValidationFluentSetter<TValue>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationFluentSetterBuilder{TValue}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assign to the property.</param>
+    /// <param name="fluentSetterViewModel">The owning view model that supports validation.</param>
+    /// <param name="propertyName">The name of the property to update. Automatically provided by the compiler when omitted.</param>
     public ValidationFluentSetterBuilder(TValue value, IValidationFluentSetterViewModel fluentSetterViewModel, [CallerMemberName] string? propertyName = null)
         : base(value, fluentSetterViewModel, propertyName)
     {
     }
 
+    /// <inheritdoc />
     protected override FluentSetter<TValue> CreateFluentSetter(IFluentSetterViewModel fluentSetterViewModel, string? propertyName)
     {
         return new ValidationFluentSetter<TValue>((IValidationFluentSetterViewModel)fluentSetterViewModel, propertyName);
@@ -20,10 +31,13 @@ public class ValidationFluentSetterBuilder<TValue> : FluentSetterBuilder<TValue>
 
     private ValidationFluentSetter<TValue> ValidationSetter => (ValidationFluentSetter<TValue>)FluentSetterInstance;
 
+    /// <inheritdoc />
     public bool HasErrors => ValidationSetter.HasErrors;
 
+    /// <inheritdoc />
     public IEnumerable GetErrors() => ValidationSetter.GetErrors();
 
+    /// <inheritdoc />
     public IValidationFluentSetter<TValue> Validate(params IValidationRule[] rules)
     {
         if (!IsBuilt)
@@ -34,6 +48,7 @@ public class ValidationFluentSetterBuilder<TValue> : FluentSetterBuilder<TValue>
         return this;
     }
 
+    /// <inheritdoc />
     public IValidationFluentSetter<TValue> Validate(Func<TValue?, bool> validationFunction, string? errorMessage)
     {
         if (!IsBuilt)
@@ -44,17 +59,20 @@ public class ValidationFluentSetterBuilder<TValue> : FluentSetterBuilder<TValue>
         return this;
     }
 
+    /// <inheritdoc />
     public IValidationFluentSetter<TValue> HasValue(string? errorMessage = null)
     {
         return Validate(new RequiredValidationRule(errorMessage));
     }
 
+    /// <inheritdoc />
     [Obsolete("Use HasValue instead.")]
     public IValidationFluentSetter<TValue> Required(string? errorMessage = null)
     {
         return HasValue(errorMessage);
     }
 
+    /// <inheritdoc />
     public void CheckForErrors(object? value)
     {
         ValidationSetter.CheckForErrors(value);

--- a/src/MVVMFluent/Validation/ValidationRule.cs
+++ b/src/MVVMFluent/Validation/ValidationRule.cs
@@ -9,5 +9,11 @@ namespace MVVMFluent.Validation;
 /// </summary>
 public abstract class ValidationRule : IValidationRule
 {
+    /// <summary>
+    /// Validates the specified value using the provided culture.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="cultureInfo">The culture to use when performing validation.</param>
+    /// <returns>A <see cref="ValidationResult"/> describing the validation outcome, or <see langword="null"/> when the value is valid.</returns>
     public abstract ValidationResult? Validate(object? value, CultureInfo cultureInfo);
 }

--- a/src/MVVMFluent/ViewModels/NotificationViewModelBase.cs
+++ b/src/MVVMFluent/ViewModels/NotificationViewModelBase.cs
@@ -4,23 +4,38 @@ using System.Runtime.CompilerServices;
 
 namespace MVVMFluent;
 
+/// <summary>
+/// Provides a base implementation for view models that raise property change notifications and manage disposable resources.
+/// </summary>
 public abstract class NotificationViewModelBase : INotifyPropertyChanged, IDisposable
 {
     private bool _disposed;
 
+    /// <inheritdoc />
     public event PropertyChangedEventHandler? PropertyChanged;
 
+    /// <summary>
+    /// Raises the <see cref="PropertyChanged"/> event for the specified property.
+    /// </summary>
+    /// <param name="propertyName">The name of the property that changed.</param>
     public void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
+    /// <summary>
+    /// Releases the resources used by the view model.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Releases the unmanaged resources used by the view model and optionally disposes of managed resources.
+    /// </summary>
+    /// <param name="disposing">A value indicating whether to dispose managed resources.</param>
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed)
@@ -37,6 +52,9 @@ public abstract class NotificationViewModelBase : INotifyPropertyChanged, IDispo
         _disposed = true;
     }
 
+    /// <summary>
+    /// Performs additional cleanup when the view model is disposed.
+    /// </summary>
     protected virtual void DisposeInternal()
     {
     }


### PR DESCRIPTION
## Summary
- add XML documentation to the asynchronous command classes to describe configuration, execution, and disposal workflows
- document synchronous command implementations, fluent setter builders, and validation helpers to clarify their responsibilities
- annotate supporting interfaces, base view models, and task extensions to eliminate documentation warnings across the library

## Testing
- `dotnet build /p:EnableWindowsTargeting=true` *(fails: TerminalLogger raised an InternalLoggerException when formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ed2f095b3883269268ea1d0c447dd4