### PR TITLE
Refactor namespaces in MVVMFluent project

### DIFF
--- a/src/MVVMFluent.Tests/AsyncFluentCommandTests.cs
+++ b/src/MVVMFluent.Tests/AsyncFluentCommandTests.cs
@@ -1,8 +1,3 @@
-using MVVMFluent.Commands;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace MVVMFluent.Tests;
 
 public class AsyncFluentCommandTests

--- a/src/MVVMFluent.Tests/Validation/ValidationFluentSetterBuilderExtensionsTests.cs
+++ b/src/MVVMFluent.Tests/Validation/ValidationFluentSetterBuilderExtensionsTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using MVVMFluent.Interfaces;
-using MVVMFluent.Validation;
 
 namespace MVVMFluent.Tests.Validation;
 

--- a/src/MVVMFluent.Tests/ViewModelBaseGenericsCommandTests.cs
+++ b/src/MVVMFluent.Tests/ViewModelBaseGenericsCommandTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace MVVMFluent.Tests
 {
-    public class CommandViewModel : ViewModelBase
-    {
-    }
+    public class CommandViewModel : ViewModelBase{ }
 
     public class ViewModelBaseGenericsCommandTests
     {

--- a/src/MVVMFluent.Tests/ViewModelBaseGenericsCommandTests.cs
+++ b/src/MVVMFluent.Tests/ViewModelBaseGenericsCommandTests.cs
@@ -1,6 +1,4 @@
-﻿using MVVMFluent.Commands;
-
-namespace MVVMFluent.Tests
+﻿namespace MVVMFluent.Tests
 {
     public class CommandViewModel : ViewModelBase
     {

--- a/src/MVVMFluent/Commands/AsyncFluentCommand.cs
+++ b/src/MVVMFluent/Commands/AsyncFluentCommand.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace MVVMFluent.Commands;
+namespace MVVMFluent;
 
 /// <summary>
 /// Represents an asynchronous command that supports cancellation and tracks execution state.

--- a/src/MVVMFluent/Commands/FluentCommand.cs
+++ b/src/MVVMFluent/Commands/FluentCommand.cs
@@ -1,7 +1,7 @@
 using MVVMFluent.Interfaces;
 using System;
 
-namespace MVVMFluent.Commands;
+namespace MVVMFluent;
 
 /// <summary>
 /// Represents a command that can be executed and has an associated execution condition.

--- a/src/MVVMFluent/ViewModels/FluentSetterViewModelBase.cs
+++ b/src/MVVMFluent/ViewModels/FluentSetterViewModelBase.cs
@@ -1,5 +1,3 @@
-using MVVMFluent.Builders;
-using MVVMFluent.Commands;
 using MVVMFluent.Interfaces;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Simplified the namespace structure by moving `AsyncFluentCommand` and `FluentCommand` from `MVVMFluent.Commands` to the root `MVVMFluent` namespace.

Removed unused `using` directives for `MVVMFluent.Builders` and `MVVMFluent.Commands` in `FluentSetterViewModelBase.cs` to clean up dependencies and improve code clarity.